### PR TITLE
Remove portal-signature-job-status-change-request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification</artifactId>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.0.NOTIFY_COMPLETE-SNAPSHOT</version>
 
 
 	<build>
@@ -58,6 +58,14 @@
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>2.8.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.1</version>
+                    <configuration>
+                        <generateBackupPoms>false</generateBackupPoms>
+                    </configuration>
                 </plugin>
 			</plugins>
 		</pluginManagement>

--- a/src/main/xsd/portal-signature-job.xsd
+++ b/src/main/xsd/portal-signature-job.xsd
@@ -77,18 +77,4 @@
         </xs:sequence>
     </xs:complexType>
 
-    <xs:element name="portal-signature-job-status-change-request">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="status" minOccurs="1" maxOccurs="1" type="portal-signature-job-sender-status"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:simpleType name="portal-signature-job-sender-status">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="CONFIRMED"/>
-        </xs:restriction>
-    </xs:simpleType>
-
 </xs:schema>

--- a/src/main/xsd/portal-signature-job.xsd
+++ b/src/main/xsd/portal-signature-job.xsd
@@ -28,7 +28,7 @@
     <xs:element name="portal-signature-job-request">
         <xs:complexType>
             <xs:annotation>
-                <xs:documentation>Contains metadata related to a signature job to be completed in the portal</xs:documentation>
+                <xs:documentation>Contains metadata related to a signature job to be signed in the portal</xs:documentation>
             </xs:annotation>
             <xs:sequence>
                 <xs:element name="reference" minOccurs="0" maxOccurs="1" type="common:signature-job-reference"/>
@@ -51,17 +51,17 @@
 
     <xs:simpleType name="portal-signature-job-status">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="COMPLETED"/>
-            <xs:enumeration value="CANCELED"/>
+            <xs:enumeration value="SIGNED"/>
+            <xs:enumeration value="CANCELLED"/>
         </xs:restriction>
     </xs:simpleType>
 
     <xs:complexType name="additional-info">
         <xs:choice>
-            <xs:element name="success-info" minOccurs="1" maxOccurs="1">
+            <xs:element name="job-signed-info" minOccurs="1" maxOccurs="1">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="links" minOccurs="1" maxOccurs="1" type="success-links"/>
+                        <xs:element name="links" minOccurs="1" maxOccurs="1" type="job-signed-links"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -69,7 +69,7 @@
         </xs:choice>
     </xs:complexType>
 
-    <xs:complexType name="success-links">
+    <xs:complexType name="job-signed-links">
         <xs:sequence>
             <xs:element name="xades-url" minOccurs="0" maxOccurs="1" type="common:url"/>
             <xs:element name="pades-url" minOccurs="0" maxOccurs="1" type="common:url"/>

--- a/src/main/xsd/signature-job.xsd
+++ b/src/main/xsd/signature-job.xsd
@@ -97,19 +97,4 @@
         </xs:sequence>
     </xs:complexType>
 
-    <xs:element name="direct-signature-job-status-change-request">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="status" minOccurs="1" maxOccurs="1" type="direct-signature-job-sender-status"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:simpleType name="direct-signature-job-sender-status">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="CONFIRMED"/>
-        </xs:restriction>
-    </xs:simpleType>
-
-
 </xs:schema>

--- a/src/main/xsd/signature-job.xsd
+++ b/src/main/xsd/signature-job.xsd
@@ -71,17 +71,17 @@
     <xs:simpleType name="direct-signature-job-status">
         <xs:restriction base="xs:string">
             <xs:enumeration value="CREATED"/>
-            <xs:enumeration value="COMPLETED"/>
-            <xs:enumeration value="CANCELED"/>
+            <xs:enumeration value="SIGNED"/>
+            <xs:enumeration value="CANCELLED"/>
         </xs:restriction>
     </xs:simpleType>
 
     <xs:complexType name="additional-info">
         <xs:choice>
-            <xs:element name="success-info" minOccurs="1" maxOccurs="1">
+            <xs:element name="job-signed-info" minOccurs="1" maxOccurs="1">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="links" minOccurs="1" maxOccurs="1" type="success-links"/>
+                        <xs:element name="links" minOccurs="1" maxOccurs="1" type="job-signed-links"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -89,7 +89,7 @@
         </xs:choice>
     </xs:complexType>
 
-    <xs:complexType name="success-links">
+    <xs:complexType name="job-signed-links">
         <xs:sequence>
             <xs:element name="xades-url" minOccurs="1" maxOccurs="1" type="common:url"/>
             <xs:element name="pades-url" minOccurs="1" maxOccurs="1" type="common:url"/>


### PR DESCRIPTION
Type is not necessary because API changes to use specific URLs for
notifying various status changes.