### PR TITLE
Relative expiration time

### DIFF
--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -219,7 +219,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-RELATIVE_EXPIRATION_TIME-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.0-RELATIVE_EXPIRATION_TIME-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/schema/examples/portal/manifest.xml
+++ b/schema/examples/portal/manifest.xml
@@ -17,6 +17,6 @@
     </document>
     <availability>
         <activation-time>2016-02-10T12:00:00+01:00</activation-time>
-        <expiration-time>2016-04-01T00:00:00+01:00</expiration-time>
+        <available-seconds>864000</available-seconds>
     </availability>
 </portal-signature-job-manifest>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -109,7 +109,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-RELATIVE_EXPIRATION_TIME-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/xsd/common.xsd
+++ b/schema/xsd/common.xsd
@@ -115,4 +115,10 @@
         </xs:attribute>
     </xs:complexType>
 
+    <xs:simpleType name="nonNegativeLong">
+        <xs:restriction base="xs:long">
+            <xs:minInclusive value="0"/>
+        </xs:restriction>
+    </xs:simpleType>
+
 </xs:schema>

--- a/schema/xsd/portal.xsd
+++ b/schema/xsd/portal.xsd
@@ -59,15 +59,13 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="expiration-time" minOccurs="0" maxOccurs="1" type="xs:dateTime">
+            <xs:element name="available-seconds" minOccurs="0" maxOccurs="1" type="xs:nonNegativeInteger">
                 <xs:annotation>
                     <xs:documentation>
-                        Specifies the latest time the document can be signed.
-                        Omitting this will set a default expiration-time for the job.
-                        Setting an expiration-time in the past, before the activation-time, or unreasonably far in the future
-                        will be rejected by the API.
+                        Specifies how many seconds after activation (i.e. seconds after activation-time if set, creation time if not) the document can be signed.
+                        Omitting this will set a default availability length for the job.
 
-                        Please refer to the documentation to determine the default expiration-time, as well as the limit for
+                        Please refer to the documentation to determine the default availability length, as well as the limit for
                         how far in the future a job can be set to expire.
                     </xs:documentation>
                 </xs:annotation>

--- a/schema/xsd/portal.xsd
+++ b/schema/xsd/portal.xsd
@@ -59,7 +59,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="available-seconds" minOccurs="0" maxOccurs="1" type="xs:nonNegativeInteger">
+            <xs:element name="available-seconds" minOccurs="0" maxOccurs="1" type="nonNegativeLong">
                 <xs:annotation>
                     <xs:documentation>
                         Specifies how many seconds after activation (i.e. seconds after activation-time if set, creation time if not) the document can be signed.


### PR DESCRIPTION
Available-seconds specifies how many seconds after activation the document can be signed.
This has been changed to a relative value to be able to support "chained signatures" (i.e. one signer is required to sign before another) in the future. In such a case it doesn't make sense to specify a single point in time where the document expires, so the sender may specify a duration the document is available _for each signer_.