### PR TITLE
Introducing signature chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,17 +284,23 @@ Følgende er et eksempel på metadata for et asynkront signeringsoppdrag:
 </portal-signature-job-request>
 ```
 
-Følgende er et eksempel på `manifest.xml` fra dokumentpakken for et signeringsoppdrag som skal signeres av to signatarer:
+Følgende er et eksempel på `manifest.xml` fra dokumentpakken for et signeringsoppdrag som skal signeres av fire signatarer:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <portal-signature-job-manifest xmlns="http://signering.posten.no/schema/v1">
     <signers>
-        <signer>
+        <signer order="1">
             <personal-identification-number>12345678910</personal-identification-number>
         </signer>
-        <signer>
-            <personal-identification-number>98765432100</personal-identification-number>
+        <signer order="2">
+            <personal-identification-number>10987654321</personal-identification-number>
+        </signer>
+        <signer order="2">
+            <personal-identification-number>01013300001</personal-identification-number>
+        </signer>
+        <signer order="3">
+            <personal-identification-number>02038412546</personal-identification-number>
         </signer>
     </signers>
     <sender>
@@ -306,10 +312,14 @@ Følgende er et eksempel på `manifest.xml` fra dokumentpakken for et signerings
     </document>
     <availability>
         <activation-time>2016-02-10T12:00:00+01:00</activation-time>
-        <expiration-time>2016-04-01T00:00:00+01:00</expiration-time>
+        <available-seconds>864000</available-seconds>
     </availability>
 </portal-signature-job-manifest>
 ```
+
+`order`-attributtet på `signer` brukes til å angi rekkefølgen på signatarene. I eksempelet over vil oppdraget først bli tilgjengelig for signatarene med `order="2"` når signataren med `order="1"`, og for signataren med `order="3"` når begge de med `order="2"` har signert.
+
+ Tiden angitt i `available-seconds` gjelder for hvert sett med signatarer i parallell, slik at alle signatarene vil ha lik frist fra oppdraget blir tilgjengelig for dem.
 
 Som respons på dette kallet vil man få en respons definert av elementet `portal-signature-job-response`. Denne responsen inneholder en ID generert av signeringstjenesten. Du må lagre denne IDen i dine systemer slik at du senere kan koble resultatene du får fra polling-mekanismen til riktig oppdrag.
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Følgende er et eksempel på `manifest.xml` fra dokumentpakken for et signerings
 </portal-signature-job-manifest>
 ```
 
-`order`-attributtet på `signer` brukes til å angi rekkefølgen på signatarene. I eksempelet over vil oppdraget først bli tilgjengelig for signatarene med `order="2"` når signataren med `order="1"`, og for signataren med `order="3"` når begge de med `order="2"` har signert.
+`order`-attributtet på `signer` brukes til å angi rekkefølgen på signatarene. I eksempelet over vil oppdraget først bli tilgjengelig for signatarene med `order="2"` når signataren med `order="1"` har signert, og for signataren med `order="3"` når begge de med `order="2"` har signert.
 
  Tiden angitt i `available-seconds` gjelder for hvert sett med signatarer i parallell, slik at alle signatarene vil ha lik frist fra oppdraget blir tilgjengelig for dem.
 

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -219,7 +219,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-CHAINS-CHAINS-CHAINS-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.0-CHAINS-CHAINS-CHAINS-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/schema/examples/portal/manifest.xml
+++ b/schema/examples/portal/manifest.xml
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <portal-signature-job-manifest xmlns="http://signering.posten.no/schema/v1">
     <signers>
-        <signer>
+        <signer order="1">
             <personal-identification-number>12345678910</personal-identification-number>
         </signer>
-        <signer>
+        <signer order="2">
             <personal-identification-number>10987654321</personal-identification-number>
+        </signer>
+        <signer order="2">
+            <personal-identification-number>01013300001</personal-identification-number>
+        </signer>
+        <signer order="3">
+            <personal-identification-number>02038412546</personal-identification-number>
         </signer>
     </signers>
     <sender>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -109,7 +109,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-CHAINS-CHAINS-CHAINS-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/xsd/common.xsd
+++ b/schema/xsd/common.xsd
@@ -59,6 +59,22 @@
             <xs:element name="personal-identification-number" minOccurs="1" maxOccurs="1"
                         type="personal-identification-number"/>
         </xs:sequence>
+        <xs:attribute name="order" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the order in which documents should be activated. Lower values indicates earlier activation.
+                    A document with higher order will only be made available when all lower order signers have signed the document.
+                    If two signers have the same order, the document will be made available to both in parallell.
+                    Specifying order with only one signer has no effect.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:integer">
+                    <xs:minInclusive value="0"/>
+                    <xs:maxInclusive value="9"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:simpleType name="personal-identification-number">

--- a/schema/xsd/common.xsd
+++ b/schema/xsd/common.xsd
@@ -66,6 +66,10 @@
                     A document with higher order will only be made available when all lower order signers have signed the document.
                     If two signers have the same order, the document will be made available to both in parallell.
                     Specifying order with only one signer has no effect.
+
+                    The specified signature deadline for portal jobs will be for each individual signer.
+                    For example, 1 day for 3 chained signers means 3 days maximum. The time only runs once for signers in paralell,
+                    so three paralell signers with 1 day deadline will maximum take 1 day.
                 </xs:documentation>
             </xs:annotation>
             <xs:simpleType>


### PR DESCRIPTION
Introducing an order attribute that can be set on the signer element, specifying the order in which the document will be made available to the signers.