### PR TITLE
Forslag til XSD-utvidelser ifm. enkel esignatur og signering uten fnr.

### DIFF
--- a/schema/examples/direct/manifest.xml
+++ b/schema/examples/direct/manifest.xml
@@ -4,13 +4,12 @@
         <personal-identification-number>12345678910</personal-identification-number>
         <signing-ceremony>
             <method>ELECTRONIC_SIGNATURE</method>
-            <authentication-level>3</authentication-level>
         </signing-ceremony>
     </signer>
     <sender>
         <organization-number>123456789</organization-number>
     </sender>
-    <document href="document.pdf" mime="application/pdf">
+    <document href="document.pdf" mime="application/pdf" authentication-level="3">
         <title>Tittel</title>
         <description>Melding til signatar</description>
     </document>

--- a/schema/examples/direct/manifest.xml
+++ b/schema/examples/direct/manifest.xml
@@ -2,6 +2,10 @@
 <direct-signature-job-manifest xmlns="http://signering.posten.no/schema/v1">
     <signer>
         <personal-identification-number>12345678910</personal-identification-number>
+        <signing-ceremony>
+            <method>ELECTRONIC_SIGNATURE</method>
+            <authentication-level>3</authentication-level>
+        </signing-ceremony>
     </signer>
     <sender>
         <organization-number>123456789</organization-number>

--- a/schema/examples/direct/multiple_signers/manifest.xml
+++ b/schema/examples/direct/multiple_signers/manifest.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <direct-signature-job-manifest xmlns="http://signering.posten.no/schema/v1">
     <signer>
-        <personal-identification-number>12345678910</personal-identification-number>
+        <reference>123abc</reference>
+        <signing-ceremony>
+            <method>ELECTRONIC_SIGNATURE</method>
+            <authentication-level>3</authentication-level>
+        </signing-ceremony>
     </signer>
     <signer>
         <personal-identification-number>10987654321</personal-identification-number>
+        <signing-ceremony>
+            <method>ADVANCED_ELECTRONIC_SIGNATURE</method>
+            <authentication-level>4</authentication-level>
+        </signing-ceremony>
     </signer>
     <sender>
         <organization-number>123456789</organization-number>

--- a/schema/examples/direct/multiple_signers/manifest.xml
+++ b/schema/examples/direct/multiple_signers/manifest.xml
@@ -4,20 +4,18 @@
         <reference>123abc</reference>
         <signing-ceremony>
             <method>ELECTRONIC_SIGNATURE</method>
-            <authentication-level>3</authentication-level>
         </signing-ceremony>
     </signer>
     <signer>
         <personal-identification-number>10987654321</personal-identification-number>
         <signing-ceremony>
             <method>ADVANCED_ELECTRONIC_SIGNATURE</method>
-            <authentication-level>4</authentication-level>
         </signing-ceremony>
     </signer>
     <sender>
         <organization-number>123456789</organization-number>
     </sender>
-    <document href="document.pdf" mime="application/pdf">
+    <document href="document.pdf" mime="application/pdf" authentication-level="4">
         <title>Tittel</title>
         <description>Melding til signatar</description>
     </document>

--- a/schema/examples/direct/multiple_signers/response.xml
+++ b/schema/examples/direct/multiple_signers/response.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <direct-signature-job-response xmlns="http://signering.posten.no/schema/v1">
     <signature-job-id>1</signature-job-id>
-    <redirect-url signer="12345678910">
+    <redirect-url signer="123abc">
         https://signering.posten.no#/redirect/P1P-rdPK03Vf-z4NZb1mtDcExjpOzzVEkwal_F9FKm0
     </redirect-url>
     <redirect-url signer="10987654321">

--- a/schema/examples/direct/multiple_signers/status-response.xml
+++ b/schema/examples/direct/multiple_signers/status-response.xml
@@ -2,10 +2,10 @@
 <direct-signature-job-status-response xmlns="http://signering.posten.no/schema/v1">
     <signature-job-id>1</signature-job-id>
     <signature-job-status>COMPLETED_SUCCESSFULLY</signature-job-status>
-    <status signer="12345678910">SIGNED</status>
+    <status signer="123abc">SIGNED</status>
     <status signer="10987654321">SIGNED</status>
     <confirmation-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/complete</confirmation-url>
-    <xades-url signer="12345678910">https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/xades/1</xades-url>
+    <xades-url signer="123abc">https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/xades/1</xades-url>
     <xades-url signer="10987654321">https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/xades/2</xades-url>
     <pades-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/pades</pades-url>
 </direct-signature-job-status-response>

--- a/schema/examples/portal/manifest.xml
+++ b/schema/examples/portal/manifest.xml
@@ -9,7 +9,6 @@
             </notifications>
             <signing-ceremony>
                 <method>ADVANCED_ELECTRONIC_SIGNATURE</method>
-                <authentication-level>4</authentication-level>
             </signing-ceremony>
         </signer>
         <signer order="2">
@@ -19,7 +18,6 @@
             </notifications>
             <signing-ceremony>
                 <method>ADVANCED_ELECTRONIC_SIGNATURE</method>
-                <authentication-level>4</authentication-level>
             </signing-ceremony>
         </signer>
         <signer order="2">
@@ -30,7 +28,6 @@
             </notifications-using-lookup>
             <signing-ceremony>
                 <method>ADVANCED_ELECTRONIC_SIGNATURE</method>
-                <authentication-level>4</authentication-level>
             </signing-ceremony>
         </signer>
         <signer order="3">
@@ -40,14 +37,13 @@
             </notifications-using-lookup>
             <signing-ceremony>
                 <method>ADVANCED_ELECTRONIC_SIGNATURE</method>
-                <authentication-level>4</authentication-level>
             </signing-ceremony>
         </signer>
     </signers>
     <sender>
         <organization-number>123456789</organization-number>
     </sender>
-    <document href="document.pdf" mime="application/pdf">
+    <document href="document.pdf" mime="application/pdf" authentication-level="4">
         <title>Tittel</title>
         <nonsensitive-title>Sensitiv tittel</nonsensitive-title>
         <description>Melding til signatar</description>

--- a/schema/examples/portal/manifest.xml
+++ b/schema/examples/portal/manifest.xml
@@ -7,12 +7,20 @@
                 <email address="signer1@example.com" />
                 <sms number="00000000" />
             </notifications>
+            <signing-ceremony>
+                <method>ADVANCED_ELECTRONIC_SIGNATURE</method>
+                <authentication-level>4</authentication-level>
+            </signing-ceremony>
         </signer>
         <signer order="2">
             <personal-identification-number>10987654321</personal-identification-number>
             <notifications>
                 <email address="signer2@example.com" />
             </notifications>
+            <signing-ceremony>
+                <method>ADVANCED_ELECTRONIC_SIGNATURE</method>
+                <authentication-level>4</authentication-level>
+            </signing-ceremony>
         </signer>
         <signer order="2">
             <personal-identification-number>01013300001</personal-identification-number>
@@ -20,12 +28,20 @@
                 <email/>
                 <sms/>
             </notifications-using-lookup>
+            <signing-ceremony>
+                <method>ADVANCED_ELECTRONIC_SIGNATURE</method>
+                <authentication-level>4</authentication-level>
+            </signing-ceremony>
         </signer>
         <signer order="3">
             <personal-identification-number>02038412546</personal-identification-number>
             <notifications-using-lookup>
                 <email/>
             </notifications-using-lookup>
+            <signing-ceremony>
+                <method>ADVANCED_ELECTRONIC_SIGNATURE</method>
+                <authentication-level>4</authentication-level>
+            </signing-ceremony>
         </signer>
     </signers>
     <sender>


### PR DESCRIPTION
Avsendere kan spesifisere pr. signatar hvilken type esignatur (`method`) som skal innhentes, og hvilket sikkerhetsnivå som kreves fra signataren.
I stedet for å inkludere fødselsnummer kan de angi en «referanse» (`reference`) som er unik pr. signatar innenfor et oppdrag. Denne referansen returneres på alle steder hvor vi ellers returnerer fødselsnummer.
