### PR TITLE
Signature without pin

### DIFF
--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -218,7 +218,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.4</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -32,7 +32,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.5</version>
+                    <version>3.5.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
@@ -46,7 +46,6 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.1</version>
                     <configuration>
                         <generateBackupPoms>false</generateBackupPoms>
                     </configuration>
@@ -89,7 +88,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>2.10.4</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -104,7 +103,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -218,7 +218,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.4.SIGN_WO_PIN-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.jvnet.jaxb2_commons</groupId>
             <artifactId>jaxb2-basics-runtime</artifactId>
-            <version>0.11.0</version>
+            <version>0.11.1</version>
         </dependency>
     </dependencies>
 
@@ -169,7 +169,7 @@
                         <plugin>
                             <groupId>org.jvnet.jaxb2_commons</groupId>
                             <artifactId>jaxb2-basics</artifactId>
-                            <version>0.11.0</version>
+                            <version>0.11.1</version>
                         </plugin>
                         <plugin>
                             <groupId>org.jvnet.jaxb2_commons</groupId>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -219,7 +219,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.SIGN_WO_PIN-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jasig.maven</groupId>
@@ -46,7 +46,7 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
 					<artifactId>license-maven-plugin</artifactId>
-					<version>3.0.rc1</version>
+					<version>3.0</version>
                     <configuration>
                         <header>src/license-header.txt</header>
                         <strictCheck>true</strictCheck>
@@ -73,7 +73,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.0.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -86,7 +86,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.1</version>
+                    <version>2.3</version>
                     <configuration>
                         <generateBackupPoms>false</generateBackupPoms>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>1.4</version>
+	<version>1.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -127,7 +127,7 @@
 		<connection>scm:git:git@github.com:digipost/signature-api-specification.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/signature-api-specification.git</developerConnection>
 		<url>https://github.com/digipost/signature-api-specification/</url>
-		<tag>1.4</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>1.4.SIGN_WO_PIN-SNAPSHOT</version>
+	<version>1.4</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -127,7 +127,7 @@
 		<connection>scm:git:git@github.com:digipost/signature-api-specification.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/signature-api-specification.git</developerConnection>
 		<url>https://github.com/digipost/signature-api-specification/</url>
-		<tag>HEAD</tag>
+		<tag>1.4</tag>
 	</scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>1.4-SNAPSHOT</version>
+	<version>1.4.SIGN_WO_PIN-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/schema/examples/direct/manifest-signer-without-pin.xml
+++ b/schema/examples/direct/manifest-signer-without-pin.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<direct-signature-job-manifest xmlns="http://signering.posten.no/schema/v1">
+    <signer>
+        <signer-identifier>Test Testesen 1234 test.testesen@example.com kundenr: 1337</signer-identifier>
+    </signer>
+    <sender>
+        <organization-number>123456789</organization-number>
+    </sender>
+    <document href="document.pdf" mime="application/pdf">
+        <title>Tittel</title>
+        <description>Melding til signatar</description>
+    </document>
+</direct-signature-job-manifest>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -109,7 +109,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.SIGN_WO_PIN-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -110,7 +110,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.4.SIGN_WO_PIN-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>1.12</version>
                 <executions>
                     <execution>
                         <goals><goal>attach-artifact</goal></goals>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -77,6 +77,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
                 <executions>
                     <execution>
                         <goals><goal>jar</goal></goals>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -110,7 +110,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.4</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/xsd/common.xsd
+++ b/schema/xsd/common.xsd
@@ -54,6 +54,14 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="signer-identifier">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="80"></xs:maxLength>
+            <xs:minLength value="1"></xs:minLength>
+        </xs:restriction>
+    </xs:simpleType>
+
+
     <xs:complexType name="sender">
         <xs:sequence>
             <xs:element name="organization-number" minOccurs="1" maxOccurs="1">

--- a/schema/xsd/direct.xsd
+++ b/schema/xsd/direct.xsd
@@ -26,8 +26,38 @@
 
     <xs:complexType name="direct-signer">
         <xs:sequence>
-            <xs:element name="personal-identification-number" minOccurs="1" maxOccurs="1"
-                        type="personal-identification-number"/>
+            <xs:choice minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A reference to one of possibly several signers of the job.
+                        This is used to identify the particular signer of the associated job
+                        later in the process.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:element name="personal-identification-number" minOccurs="1" maxOccurs="1"
+                            type="personal-identification-number">
+                    <xs:annotation>
+                        <xs:documentation><![CDATA[
+                            Refer to a signer by a personal identification number.
+                            <p>
+                            See also
+                            <a href="https://www.skatteetaten.no/en/International-pages/Felles-innhold-benyttes-i-flere-malgrupper/Articles/Norwegian-national-ID-numbers/">
+                                https://www.skatteetaten.no/en/International-pages/Felles-innhold-benyttes-i-flere-malgrupper/Articles/Norwegian-national-ID-numbers/
+                            </a>.
+                            </p>
+                        ]]></xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="signer-identifier" minOccurs="1" maxOccurs="1"
+                            type="signer-identifier">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Refer to a signer using a custom identifier string. This string can be any ID recognized
+                            by the sender, and must uniquely identify the signer within a job.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
         </xs:sequence>
     </xs:complexType>
 
@@ -138,7 +168,7 @@ Defaults to WAIT_FOR_CALLBACK if omitted.
     <xs:complexType name="signer-specific-url">
         <xs:simpleContent>
             <xs:extension base="url">
-                <xs:attribute name="signer" type="personal-identification-number" use="optional" />
+                <xs:attribute name="signer" type="xs:string" use="optional" />
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
@@ -192,7 +222,7 @@ Currently known values:
         The signed document artifacts can be downloaded by following the appropriate urls in the direct-signature-job-status-response.
                     </xs:documentation>
                 </xs:annotation>
-                <xs:attribute name="signer" type="personal-identification-number" />
+                <xs:attribute name="signer" type="xs:string" />
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
En direct-signer kan spesifiseres _enten_ med
`personal-identification-number` (som før), eller med en
`signer-identifier`. Denne identifieren følger undertegnerene gjennom hele
signeringsprosessen for å referere til en undertegner i et
signeringsoppdrag.

Kommentar
---------------------
Oppførselen til signeringstjenesten blir ved bruk av `signer-identifier` at resulterende signerte dokument-artifakter (XAdES og PAdES) angir undertegner(e) med navn og fødselsdato, _ikke_ fødselsnummer. APIet legger ingen restriksjoner for at en multisignatar directjob må angi `signer`s _kun_ på den ene eller den andre måten, og det er heller ingen teknisk grunn til å begrense dette da det vil fly helt fint. Signeringstjenesten vil håndtere dette slik:

1. undertegnere får uansett kun tilgang til egen signatur i PAdES (og attached XAdES). Denne vil ha fødselsnummer _dersom_ undertegner var adressert med fødselsnummer av avsender
2. XAdES-er "inni" avsenders PAdES (ferdigsignert dokument) vil i alle tilfeller inneholde fødselsnumre til de som ble adressert med fødselsnummer
3. avsender får PAdES som viser undertegnere med fødselsnummer _kun_ dersom _alle_ undertegnere i oppdraget var adressert med fødselsnummer. Ellers vil _alle_ undertegnere vises med navn+fødselsdato i PAdES. (ev. adresserte fødselsnumre vil likevel ligge i attached XAdES, se pkt. 2)


