### PR TITLE
Ekskluder fødselsnummer i signerte dokumenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Følgende er et eksempel på `manifest.xml` fra dokumentpakken:
         <description>Melding til signatar</description>
     </document>
     <required-authentication>3</required-authentication>
+    <identifier-in-signed-documents>PERSONAL_IDENTIFICATION_NUMBER_AND_NAME</identifier-in-signed-documents>
 </direct-signature-job-manifest>
 ```
 
@@ -237,6 +238,12 @@ Merk at [`signature-type`](https://digipost.github.io/signature-api-specificatio
 Sikkerhetsnivå (`required-authentication`) spesifiseres på jobbnivå ettersom dette også er knyttet til dokumentets sensitivitetsnivå.
 
 *For offentlige avsendere* kan man for elementet `on-behalf-of` under `signer` sende inn verdien `OTHER` for å angi at man signerer på vegne av en tredjepart (f.eks. signering av anskaffelseskontrakt på vegne av arbeidsgiver). Elementet er valgfritt, og verdien `SELF`, altså signering på egne vegne, benyttes om man ikke angir noe. I første omgang benyttes denne verdien kun til å deaktivere videresending av signerte dokumenter til digital postkasse; signerer man på vegne av noen andre (`OTHER`) vil videresending deaktiveres. Videresending er altså aktivert som standard.
+
+`identifier-in-signed-documents` brukes for å angi hvordan undertegneren(e) skal identifiseres i de signerte dokumentene.
+Tillatte verdier er `PERSONAL_IDENTIFICATION_NUMBER_AND_NAME`, `DATE_OF_BIRTH_AND_NAME` og `NAME`, men ikke alle er gyldige for alle typer signeringsoppdrag og avsendere.
+Disse begrensningene og standardverdier er beskrevet i [den funksjonelle dokumentasjonen](http://digipost.github.io/signature-api-specification/v1.0/#undertegners-identifikator). 
+
+---
 
 Som respons på dette kallet vil man få en respons definert av elementet `direct-signature-job-response`.
 
@@ -378,6 +385,7 @@ Følgende er et eksempel på `manifest.xml` fra dokumentpakken for et signerings
         <activation-time>2016-02-10T12:00:00+01:00</activation-time>
         <available-seconds>864000</available-seconds>
     </availability>
+    <identifier-in-signed-documents>PERSONAL_IDENTIFICATION_NUMBER_AND_NAME</identifier-in-signed-documents>
 </portal-signature-job-manifest>
 ```
 
@@ -411,6 +419,12 @@ For private virksomheter vil man kunne velge fritt mellom `SELF` og `OTHER`, men
 `availability` brukes til å kontrollere tidsrommet et dokument er tilgjengelig for mottaker(e) for signering.
 Tidspunktet angitt i `activation-time` angir når jobben aktiveres, og de første signatarene får tilgang til dokumentet til signering.
 Tiden angitt i `available-seconds` gjelder for alle signatarer; d.v.s alle signatarer vil ha like lang tid på seg til å signere eller avvise mottatt dokument fra det blir tilgjengelig for dem. Dette tidsrommet gjelder altså _for hvert sett med signatarer med samme `order`_. Dersom man angir f.eks. _345600_ sekunder (4 dager) vil signatarer med `order=1` få maks 4 dager fra `activation-time` til å signere. Signatarer med `order=2` vil få tilgjengeliggjort dokumentet umiddelbart når _alle signatarer med `order=1` har signert_, og de vil da få maks 4 nye dager fra _tidspunktet de fikk dokumentet tilgjengelig_. En jobb utløper og stopper dersom minst 1 signatar ikke agerer innenfor sitt tidsrom når dokumentet er tilgjengelig. Dersom man utelater `availability` vil jobben aktiveres umiddelbart, og dokumentet vil være tilgjengelig i maks 2 592 000 sekunder (30 dager) for hvert sett med `order`-grupperte signatarer. Jobber som angir større `available-seconds` enn 7 776 000 sekunder (90 dager) blir avvist av tjenesten.
+
+`identifier-in-signed-documents` brukes for å angi hvordan undertegneren(e) skal identifiseres i de signerte dokumentene.
+Tillatte verdier er `PERSONAL_IDENTIFICATION_NUMBER_AND_NAME`, `DATE_OF_BIRTH_AND_NAME` og `NAME`, men ikke alle er gyldige for alle typer signeringsoppdrag og avsendere.
+Disse begrensningene er beskrevet i [den funksjonelle dokumentasjonen](http://digipost.github.io/signature-api-specification/v1.0/#undertegners-identifikator). 
+
+---
 
 Som respons på dette kallet vil man få en respons definert av elementet `portal-signature-job-response`. Denne responsen inneholder en ID generert av signeringstjenesten. Du må lagre denne IDen i dine systemer slik at du senere kan koble resultatene du får fra polling-mekanismen til riktig oppdrag.
 

--- a/docs/_v1_0/2_signeringsoppdrag.md
+++ b/docs/_v1_0/2_signeringsoppdrag.md
@@ -44,6 +44,7 @@ Ved opprettelse av signeringsoppdrag kan følgende felter oppgis:
 | Signaturtype            | Valgfritt        | Valgfritt         | se [signaturtype](#signaturtype) |
 | Sikkerhetsnivå          | Valgfritt        | Valgfritt         | se [sikkerhetsnivå](#sikkerhetsniv) |
 | Melding til mottaker(e) | Valgfritt        | Valgfritt         |   |
+| Undertegners identifikator | Valgfritt     | Valgfritt         | se [undertegners identifikator](#undertegners-identifikator) |
 | Aktiveringstidspunkt    | _Ikke relevant_  | Valgfritt         |   |
 | Levetid                 | _Ikke relevant_  | Valgfritt         |   |
 | E-postadresse           | _Ikke relevant_  | __Obligatorisk__  | se [varsling](#varsling) |

--- a/docs/_v1_0/6_signerte_dokumenter.md
+++ b/docs/_v1_0/6_signerte_dokumenter.md
@@ -9,3 +9,20 @@ Tjenesten tilgjengeliggjør signaturer i to formater når et dokument har blitt 
 PAdES er tilgjengelig når minst én signatar har signert og vil inneholde de signaturene som er gjennomført for oppdraget i nedlastningsøyeblikket. XAdES er tilgjengelig fra det øyeblikket signataren har signert dokumentet.
 
 Alle dokumenter kan lastes ned i en periode etter at signeringsoppdraget er fullført. Levetiden er avhengig av om [dokumentarkivet](#dokumentarkiv) er aktivert for avsenderen.
+
+## Undertegners identifikator
+
+Avsender kan, under opprettelse av signeringsoppdrag, velge hvordan undertegnerene skal identifiseres i de signerte dokumentene.
+Dette kan for eksempel være nyttig hvis dokumentet skal signeres av flere enn én person og du ikke ønsker å utlevere fødselsnumrene.
+
+Standardverdi dersom avsender ikke overstyrer er at undertegnerene identifiseres ved navn og fødselsnummer.
+Unntaket er hvis undertegnerene er [adressert uten fødselsnummer](#adressering-uten-fdselsnummer), hvor de signerte dokumentene alltid inneholder navn og fødselsdato.
+
+* For avanserte e-signaturer kan avsender angi at signerte dokumenter skal inneholde _navn og fødselsdato_.
+* For autentiserte e-signaturer kan avsender angi at signerte dokumenter skal inneholde _kun navn_.
+
+**NB!** Offentlige avsendere kan ikke ekskludere fødselsnummeret i _avanserte e-signaturer_.
+
+Hvis du utelater fødselsnummer i de signerte dokumentene kan vi ikke påvise identiteten med 100% sikkerhet. Vi kan likevel i de aller fleste tilfeller oppnå tilstrekkelig beviskraft, på bakgrunn av kontektsten signeringen skjer i.
+
+Sannsynligheten er for eksempel svært liten for at 2 personer med navn Kari Olsen signerer en lærekontrakt med Lærlingebedrift AS på eksakt samme tidspunkt. I tillegg vil tekniske spor (audit trail), og andre eksterne forhold som kunderelasjon eller opplysninger i dokumentet også støtte opp under identiteten til den som har signert.

--- a/docs/_v1_0/6_signerte_dokumenter.md
+++ b/docs/_v1_0/6_signerte_dokumenter.md
@@ -12,17 +12,19 @@ Alle dokumenter kan lastes ned i en periode etter at signeringsoppdraget er full
 
 ## Undertegners identifikator
 
-Avsender kan, under opprettelse av signeringsoppdrag, velge hvordan undertegnerene skal identifiseres i de signerte dokumentene.
-Dette kan for eksempel være nyttig hvis dokumentet skal signeres av flere enn én person og du ikke ønsker å utlevere fødselsnumrene.
+Avsender kan, under opprettelse av signeringsoppdrag, velge hvordan undertegnerne skal identifiseres i de signerte dokumentene.
+Dette kan for eksempel være nyttig hvis dokumentet skal signeres av flere enn én person og du ikke ønsker å utlevere fødselsnumrene til undertegnerne.
 
-Standardverdi dersom avsender ikke overstyrer er at undertegnerene identifiseres ved navn og fødselsnummer.
-Unntaket er hvis undertegnerene er [adressert uten fødselsnummer](#adressering-uten-fdselsnummer), hvor de signerte dokumentene alltid inneholder navn og fødselsdato.
+Standardverdi, dersom avsender ikke overstyrer, er at undertegnerne identifiseres ved navn og fødselsnummer.
+Unntaket er hvis undertegnerne er [adressert uten fødselsnummer](#adressering-uten-fdselsnummer), hvor de signerte dokumentene alltid inneholder navn og fødselsdato.
 
 * For avanserte e-signaturer kan avsender angi at signerte dokumenter skal inneholde _navn og fødselsdato_.
-* For autentiserte e-signaturer kan avsender angi at signerte dokumenter skal inneholde _kun navn_.
+* For autentiserte e-signaturer kan avsender angi at signerte dokumenter skal inneholde _kun navn_ (kun tilgjengelig for offentlige avsendere).
 
 **NB!** Offentlige avsendere kan ikke ekskludere fødselsnummeret i _avanserte e-signaturer_.
 
-Hvis du utelater fødselsnummer i de signerte dokumentene kan vi ikke påvise identiteten med 100% sikkerhet. Vi kan likevel i de aller fleste tilfeller oppnå tilstrekkelig beviskraft, på bakgrunn av kontektsten signeringen skjer i.
+Hvis du utelater fødselsnummer i de signerte dokumentene kan vi ikke påvise identiteten med 100 % sikkerhet<sup>[1](#fotnote-e-id-identifikator)</sup>. Vi kan likevel i de aller fleste tilfeller oppnå tilstrekkelig beviskraft, på bakgrunn av konteksten signeringen skjer i.
 
 Sannsynligheten er for eksempel svært liten for at 2 personer med navn Kari Olsen signerer en lærekontrakt med Lærlingebedrift AS på eksakt samme tidspunkt. I tillegg vil tekniske spor (audit trail), og andre eksterne forhold som kunderelasjon eller opplysninger i dokumentet også støtte opp under identiteten til den som har signert.
+
+<a name="fotnote-e-id-identifikator"><sup>1</sup></a> Det signerte dokumentet inneholder en anonymisert identifikator som identifiserer undertegneren med 100 % sikkerhet hos leverandøren av e-ID, for eksempel hos BankID. Dette krever oppslag hos leverandøren av e-ID og støttes kun ved avansert e-signatur.

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -268,7 +268,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.9</version>
+        <version>1.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -268,7 +268,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.9-EXCLUDE_PIN-SNAPSHOT</version>
+        <version>1.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -268,7 +268,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.9-SNAPSHOT</version>
+        <version>1.9-EXCLUDE_PIN-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
+++ b/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
@@ -30,6 +30,7 @@ import java.util.Date;
 import static junit.framework.TestCase.assertEquals;
 import static no.digipost.signature.api.xml.XMLAuthenticationLevel.FOUR;
 import static no.digipost.signature.api.xml.XMLAuthenticationLevel.THREE;
+import static no.digipost.signature.api.xml.XMLIdentifierInSignedDocuments.PERSONAL_IDENTIFICATION_NUMBER_AND_NAME;
 import static no.digipost.signature.api.xml.XMLStatusRetrievalMethod.WAIT_FOR_CALLBACK;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -53,13 +54,13 @@ public class SignatureJaxb2MarshallerTest {
                 .withErrorUrl("http://localhost/failed");
 
         XMLDirectSignatureJobRequest directJob = new XMLDirectSignatureJobRequest("123abc", exitUrls, null);
-        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Arrays.asList(directSigner), sender, directDocument, THREE);
+        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Arrays.asList(directSigner), sender, directDocument, THREE, PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
 
         marshaller.marshal(directJob, new StreamResult(new ByteArrayOutputStream()));
         marshaller.marshal(directManifest, new StreamResult(new ByteArrayOutputStream()));
 
         XMLPortalSignatureJobRequest portalJob = new XMLPortalSignatureJobRequest("123abc");
-        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Arrays.asList(portalSigner), sender, portalDocument, FOUR, new XMLAvailability().withActivationTime(new Date()));
+        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Arrays.asList(portalSigner), sender, portalDocument, FOUR, new XMLAvailability().withActivationTime(new Date()), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
         marshaller.marshal(portalJob, new StreamResult(new ByteArrayOutputStream()));
         marshaller.marshal(portalManifest, new StreamResult(new ByteArrayOutputStream()));
     }
@@ -89,8 +90,8 @@ public class SignatureJaxb2MarshallerTest {
         XMLPortalDocument portalDocument = new XMLPortalDocument("Title", "nonsensitive title", "Description", null, "application/pdf");
         XMLDirectDocument directDocument = new XMLDirectDocument("Title", "Description", null, "application/pdf");
 
-        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Arrays.asList(directSigner), sender, directDocument, FOUR);
-        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Arrays.asList(portalSigner), sender, portalDocument, FOUR, new XMLAvailability());
+        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Arrays.asList(directSigner), sender, directDocument, FOUR, PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
+        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Arrays.asList(portalSigner), sender, portalDocument, FOUR, new XMLAvailability(), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
 
         try {
             marshaller.marshal(directManifest, new StreamResult(new ByteArrayOutputStream()));

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>1.9</version>
+	<version>1.10-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -148,7 +148,7 @@
 		<connection>scm:git:git@github.com:digipost/signature-api-specification.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/signature-api-specification.git</developerConnection>
 		<url>https://github.com/digipost/signature-api-specification/</url>
-		<tag>1.9</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>1.9-SNAPSHOT</version>
+	<version>1.9-EXCLUDE_PIN-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>1.9-EXCLUDE_PIN-SNAPSHOT</version>
+	<version>1.9</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -148,7 +148,7 @@
 		<connection>scm:git:git@github.com:digipost/signature-api-specification.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/signature-api-specification.git</developerConnection>
 		<url>https://github.com/digipost/signature-api-specification/</url>
-		<tag>HEAD</tag>
+		<tag>1.9</tag>
 	</scm>
 
 

--- a/schema/examples/direct/manifest-signer-without-pin.xml
+++ b/schema/examples/direct/manifest-signer-without-pin.xml
@@ -10,4 +10,5 @@
         <title>Tittel</title>
         <description>Melding til signatar</description>
     </document>
+    <identifier-in-signed-documents>DATE_OF_BIRTH_AND_NAME</identifier-in-signed-documents>
 </direct-signature-job-manifest>

--- a/schema/examples/direct/manifest-specify-signtype-and-auth.xml
+++ b/schema/examples/direct/manifest-specify-signtype-and-auth.xml
@@ -12,4 +12,5 @@
         <description>Melding til signatar</description>
     </document>
     <required-authentication>3</required-authentication>
+    <identifier-in-signed-documents>PERSONAL_IDENTIFICATION_NUMBER_AND_NAME</identifier-in-signed-documents>
 </direct-signature-job-manifest>

--- a/schema/examples/direct/manifest.xml
+++ b/schema/examples/direct/manifest.xml
@@ -11,4 +11,5 @@
         <title>Tittel</title>
         <description>Melding til signatar</description>
     </document>
+    <identifier-in-signed-documents>PERSONAL_IDENTIFICATION_NUMBER_AND_NAME</identifier-in-signed-documents>
 </direct-signature-job-manifest>

--- a/schema/examples/direct/multiple_signers/manifest.xml
+++ b/schema/examples/direct/multiple_signers/manifest.xml
@@ -13,4 +13,5 @@
         <title>Tittel</title>
         <description>Melding til signatar</description>
     </document>
+    <identifier-in-signed-documents>DATE_OF_BIRTH_AND_NAME</identifier-in-signed-documents>
 </direct-signature-job-manifest>

--- a/schema/examples/portal/manifest-signer-without-pin.xml
+++ b/schema/examples/portal/manifest-signer-without-pin.xml
@@ -27,4 +27,5 @@
         <activation-time>2016-02-10T12:00:00+01:00</activation-time>
         <available-seconds>864000</available-seconds>
     </availability>
+    <identifier-in-signed-documents>DATE_OF_BIRTH_AND_NAME</identifier-in-signed-documents>
 </portal-signature-job-manifest>

--- a/schema/examples/portal/manifest-specify-on-behalf-of.xml
+++ b/schema/examples/portal/manifest-specify-on-behalf-of.xml
@@ -22,4 +22,5 @@
         <activation-time>2016-02-10T12:00:00+01:00</activation-time>
         <available-seconds>864000</available-seconds>
     </availability>
+    <identifier-in-signed-documents>NAME</identifier-in-signed-documents>
 </portal-signature-job-manifest>

--- a/schema/examples/portal/manifest-specify-signtype-and-auth.xml
+++ b/schema/examples/portal/manifest-specify-signtype-and-auth.xml
@@ -45,4 +45,5 @@
         <activation-time>2016-02-10T12:00:00+01:00</activation-time>
         <available-seconds>864000</available-seconds>
     </availability>
+    <identifier-in-signed-documents>PERSONAL_IDENTIFICATION_NUMBER_AND_NAME</identifier-in-signed-documents>
 </portal-signature-job-manifest>

--- a/schema/examples/portal/manifest.xml
+++ b/schema/examples/portal/manifest.xml
@@ -40,4 +40,5 @@
         <activation-time>2016-02-10T12:00:00+01:00</activation-time>
         <available-seconds>864000</available-seconds>
     </availability>
+    <identifier-in-signed-documents>PERSONAL_IDENTIFICATION_NUMBER_AND_NAME</identifier-in-signed-documents>
 </portal-signature-job-manifest>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -110,7 +110,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.9-SNAPSHOT</version>
+        <version>1.9-EXCLUDE_PIN-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -110,7 +110,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.9</version>
+        <version>1.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -110,7 +110,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.9-EXCLUDE_PIN-SNAPSHOT</version>
+        <version>1.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/xsd/common.xsd
+++ b/schema/xsd/common.xsd
@@ -101,4 +101,12 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="identifier-in-signed-documents">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="PERSONAL_IDENTIFICATION_NUMBER_AND_NAME"/>
+            <xs:enumeration value="DATE_OF_BIRTH_AND_NAME"/>
+            <xs:enumeration value="NAME"/>
+        </xs:restriction>
+    </xs:simpleType>
+
 </xs:schema>

--- a/schema/xsd/direct.xsd
+++ b/schema/xsd/direct.xsd
@@ -137,6 +137,7 @@ Defaults to WAIT_FOR_CALLBACK if omitted.
                 <xs:element name="sender" minOccurs="1" maxOccurs="1" type="sender"/>
                 <xs:element name="document" minOccurs="1" maxOccurs="1" type="direct-document"/>
                 <xs:element name="required-authentication" type="authentication-level" minOccurs="0" maxOccurs="1" />
+                <xs:element name="identifier-in-signed-documents" minOccurs="0" type="identifier-in-signed-documents"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>

--- a/schema/xsd/portal.xsd
+++ b/schema/xsd/portal.xsd
@@ -160,6 +160,7 @@ so three paralell signers with 1 day deadline will maximum take 1 day.
                 <xs:element name="document" minOccurs="1" maxOccurs="1" type="portal-document"/>
                 <xs:element name="required-authentication" type="authentication-level" minOccurs="0" maxOccurs="1" />
                 <xs:element name="availability" minOccurs="0" maxOccurs="1" type="availability"/>
+                <xs:element name="identifier-in-signed-documents" minOccurs="0" type="identifier-in-signed-documents"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>


### PR DESCRIPTION
Nytt frivillig element på oppdragsnivå, `identifier-in-signed-documents` med tre mulige verdier:

1. `PERSONAL_IDENTIFICATION_NUMBER_AND_NAME`
1. `DATE_OF_BIRTH_AND_NAME`
1. `NAME`

Standardverdier hvis avsender ikke sender inn elementet utledes i tjenesten, avhengig av hvordan undertegnerene er adressert og om det innhentes autentisert eller avansert signatur.