### PR TITLE
Oppdaterer til Java 8

### DIFF
--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -6,8 +6,8 @@
     <artifactId>signature-api-specification-jaxb</artifactId>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
 
         <xsd.directory>${project.basedir}/target/generated-resources/xsd</xsd.directory>
     </properties>
@@ -141,6 +141,7 @@
                 </executions>
                 <configuration>
                     <excludePackageNames>no.digipost.signature.api.xml.thirdparty.xmldsig</excludePackageNames>
+                    <additionalparam>-Xdoclint:-missing</additionalparam>
                 </configuration>
             </plugin>
             <plugin>
@@ -243,32 +244,10 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>doclint-java8-disable</id>
-            <activation>
-                <jdk>[1.8,</jdk>
-            </activation>
-
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <additionalparam>-Xdoclint:-missing</additionalparam>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-    </profiles>
-
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.10-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -247,7 +247,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -247,7 +247,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.0</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jaxb/src/main/java/no/digipost/signature/jaxb/XSDateTimeAdapter.java
+++ b/jaxb/src/main/java/no/digipost/signature/jaxb/XSDateTimeAdapter.java
@@ -17,24 +17,28 @@ package no.digipost.signature.jaxb;
 
 import javax.xml.bind.DatatypeConverter;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
-import java.util.Date;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
 import java.util.GregorianCalendar;
 
-public class XSDateTimeAdapter extends XmlAdapter<String, Date> {
+public class XSDateTimeAdapter extends XmlAdapter<String, ZonedDateTime> {
 
-	@Override
-	public Date unmarshal(final String value) {
-        return DatatypeConverter.parseDateTime(value).getTime();
-	}
-
-	@Override
-	public String marshal(final Date value) {
+    @Override
+    public ZonedDateTime unmarshal(final String value) {
         if (value == null) {
             return null;
         }
-        GregorianCalendar calendar = new GregorianCalendar();
-        calendar.setTime(value);
-        return DatatypeConverter.printDateTime(calendar);
-	}
+        Calendar parsed = DatatypeConverter.parseDate(value);
+        return ZonedDateTime.ofInstant(parsed.toInstant(), parsed.getTimeZone().toZoneId());
+    }
+
+    @Override
+    public String marshal(final ZonedDateTime value) {
+        if (value == null) {
+            return null;
+        }
+
+        return DatatypeConverter.printDateTime(GregorianCalendar.from(value));
+    }
 
 }

--- a/jaxb/src/main/jaxb/bindings.xjb
+++ b/jaxb/src/main/jaxb/bindings.xjb
@@ -25,12 +25,12 @@
 
     <globalBindings>
         <xjc:simple/>
-        <xjc:javaType adapter="no.digipost.signature.jaxb.XSDateTimeAdapter" name="java.util.Date" xmlType="xs:dateTime"/>
+        <xjc:javaType adapter="no.digipost.signature.jaxb.XSDateTimeAdapter" name="java.time.ZonedDateTime" xmlType="xs:dateTime"/>
     </globalBindings>
 
     <bindings schemaLocation="../../../target/generated-resources/xsd/direct-and-portal.xsd" node="/xs:schema">
         <schemaBindings>
-            <package name="no.digipost.signature.api.xml"></package>
+            <package name="no.digipost.signature.api.xml"/>
             <nameXmlTransform>
                 <typeName prefix="XML" />
                 <anonymousTypeName prefix="XML" />

--- a/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
+++ b/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
@@ -15,7 +15,20 @@
  */
 package no.digipost.signature.jaxb.spring;
 
-import no.digipost.signature.api.xml.*;
+import no.digipost.signature.api.xml.XMLAvailability;
+import no.digipost.signature.api.xml.XMLDirectDocument;
+import no.digipost.signature.api.xml.XMLDirectSignatureJobManifest;
+import no.digipost.signature.api.xml.XMLDirectSignatureJobRequest;
+import no.digipost.signature.api.xml.XMLDirectSignatureJobStatusResponse;
+import no.digipost.signature.api.xml.XMLDirectSigner;
+import no.digipost.signature.api.xml.XMLEnabled;
+import no.digipost.signature.api.xml.XMLExitUrls;
+import no.digipost.signature.api.xml.XMLNotificationsUsingLookup;
+import no.digipost.signature.api.xml.XMLPortalDocument;
+import no.digipost.signature.api.xml.XMLPortalSignatureJobManifest;
+import no.digipost.signature.api.xml.XMLPortalSignatureJobRequest;
+import no.digipost.signature.api.xml.XMLPortalSigner;
+import no.digipost.signature.api.xml.XMLSender;
 import org.junit.Test;
 import org.springframework.oxm.MarshallingFailureException;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
@@ -24,8 +37,8 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Date;
 
 import static junit.framework.TestCase.assertEquals;
 import static no.digipost.signature.api.xml.XMLAuthenticationLevel.FOUR;
@@ -60,7 +73,7 @@ public class SignatureJaxb2MarshallerTest {
         marshaller.marshal(directManifest, new StreamResult(new ByteArrayOutputStream()));
 
         XMLPortalSignatureJobRequest portalJob = new XMLPortalSignatureJobRequest("123abc");
-        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Arrays.asList(portalSigner), sender, portalDocument, FOUR, new XMLAvailability().withActivationTime(new Date()), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
+        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Arrays.asList(portalSigner), sender, portalDocument, FOUR, new XMLAvailability().withActivationTime(ZonedDateTime.now()), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
         marshaller.marshal(portalJob, new StreamResult(new ByteArrayOutputStream()));
         marshaller.marshal(portalManifest, new StreamResult(new ByteArrayOutputStream()));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>1.10-SNAPSHOT</version>
+	<version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>2.0-SNAPSHOT</version>
+	<version>2.0</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -148,7 +148,7 @@
 		<connection>scm:git:git@github.com:digipost/signature-api-specification.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/signature-api-specification.git</developerConnection>
 		<url>https://github.com/digipost/signature-api-specification/</url>
-		<tag>HEAD</tag>
+		<tag>2.0</tag>
 	</scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>2.0</version>
+	<version>2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -148,7 +148,7 @@
 		<connection>scm:git:git@github.com:digipost/signature-api-specification.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/signature-api-specification.git</developerConnection>
 		<url>https://github.com/digipost/signature-api-specification/</url>
-		<tag>2.0</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -110,7 +110,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.0</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -110,7 +110,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>1.10-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -110,7 +110,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Siden vi kutter støtten for Java 7 i klientbiblioteket bytter vi ut bruken av `java.util.Date` med `java.time.ZonedDateTime` som ble introdusert i JDK 8.