### PR TITLE
Inkluderer oppdragets referanse i alle responser knytta til et oppdrag

### DIFF
--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -247,7 +247,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.3</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -247,7 +247,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>2.3-SNAPSHOT</version>
+	<version>2.3</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -148,7 +148,7 @@
 		<connection>scm:git:git@github.com:digipost/signature-api-specification.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/signature-api-specification.git</developerConnection>
 		<url>https://github.com/digipost/signature-api-specification/</url>
-		<tag>HEAD</tag>
+		<tag>2.3</tag>
 	</scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>2.3</version>
+	<version>2.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -148,7 +148,7 @@
 		<connection>scm:git:git@github.com:digipost/signature-api-specification.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/signature-api-specification.git</developerConnection>
 		<url>https://github.com/digipost/signature-api-specification/</url>
-		<tag>2.3</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -110,7 +110,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -110,7 +110,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.3</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/schema/xsd/direct.xsd
+++ b/schema/xsd/direct.xsd
@@ -177,6 +177,7 @@ for the default queue.
     <xs:element name="direct-signature-job-response">
         <xs:complexType>
             <xs:sequence>
+                <xs:element name="reference" minOccurs="0" maxOccurs="1" type="signature-job-reference"/>
                 <xs:element name="signature-job-id" minOccurs="1" maxOccurs="1" type="signature-job-id"/>
                 <xs:element name="redirect-url" minOccurs="1" maxOccurs="10" type="signer-specific-url" />
                 <xs:element name="status-url" minOccurs="0" maxOccurs="1" type="url"/>
@@ -195,6 +196,7 @@ for the default queue.
     <xs:element name="direct-signature-job-status-response">
         <xs:complexType>
             <xs:sequence>
+                <xs:element name="reference" minOccurs="0" maxOccurs="1" type="signature-job-reference"/>
                 <xs:element name="signature-job-id" minOccurs="1" maxOccurs="1" type="signature-job-id"/>
                 <xs:element name="signature-job-status" minOccurs="1" maxOccurs="1" type="direct-signature-job-status"/>
                 <xs:element name="status" minOccurs="1" maxOccurs="10" type="signer-status"/>

--- a/schema/xsd/portal.xsd
+++ b/schema/xsd/portal.xsd
@@ -208,6 +208,7 @@ how far in the future a job can be set to expire.
     <xs:element name="portal-signature-job-response">
         <xs:complexType>
             <xs:sequence>
+                <xs:element name="reference" minOccurs="0" maxOccurs="1" type="signature-job-reference"/>
                 <xs:element name="signature-job-id" minOccurs="1" maxOccurs="1" type="signature-job-id"/>
                 <xs:element name="cancellation-url" minOccurs="1" maxOccurs="1" type="url"/>
             </xs:sequence>
@@ -217,6 +218,7 @@ how far in the future a job can be set to expire.
     <xs:element name="portal-signature-job-status-change-response">
         <xs:complexType>
             <xs:sequence>
+                <xs:element name="reference" minOccurs="0" maxOccurs="1" type="signature-job-reference"/>
                 <xs:element name="signature-job-id" minOccurs="1" maxOccurs="1" type="signature-job-id"/>
                 <xs:element name="status" minOccurs="1" maxOccurs="1" type="portal-signature-job-status"/>
                 <xs:element name="confirmation-url" minOccurs="1" maxOccurs="1" type="url" >


### PR DESCRIPTION
Dette kan være nyttig hvis klienter ikke ønsker å ta vare på IDen som
returneres fra tjenesten, men heller vil bruke sin interne referanse.