### PR TITLE
Restructuring of POM xml

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-P build-sources-and-javadoc

--- a/NOTICE
+++ b/NOTICE
@@ -8,18 +8,11 @@ Licensed under Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.html
 
 This software includes third party software subject to the following licenses:
 
-  Hamcrest Core under New BSD License
-  Hamcrest library under New BSD License
+  JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
+  jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.1.1 implemented over SLF4J under MIT License
-  JUnit under Eclipse Public License 1.0
   Posten signering - API JAXB Classes under The Apache Software License, Version 2.0
   Posten signering - API Schema under The Apache Software License, Version 2.0
   Posten signering - API Specification under The Apache Software License, Version 2.0
-  SLF4J API Module under MIT License
-  SLF4J Simple Binding under MIT License
-  Spring Beans under The Apache Software License, Version 2.0
-  Spring Core under The Apache Software License, Version 2.0
-  Spring Object/XML Marshalling under The Apache Software License, Version 2.0
 
 

--- a/jaxb/NOTICE
+++ b/jaxb/NOTICE
@@ -8,17 +8,9 @@ Licensed under Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.html
 
 This software includes third party software subject to the following licenses:
 
-  Hamcrest Core under New BSD License
-  Hamcrest library under New BSD License
+  JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
+  jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.1.1 implemented over SLF4J under MIT License
-  JUnit under Eclipse Public License 1.0
   Posten signering - API JAXB Classes under The Apache Software License, Version 2.0
-  Posten signering - API Schema under The Apache Software License, Version 2.0
-  SLF4J API Module under MIT License
-  SLF4J Simple Binding under MIT License
-  Spring Beans under The Apache Software License, Version 2.0
-  Spring Core under The Apache Software License, Version 2.0
-  Spring Object/XML Marshalling under The Apache Software License, Version 2.0
 
 

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -1,18 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>no.digipost.signature</groupId>
+        <artifactId>signature-api-specification-parent</artifactId>
+        <version>2.4-SNAPSHOT</version>
+    </parent>
+
     <name>Posten signering - API JAXB Classes</name>
 
     <artifactId>signature-api-specification-jaxb</artifactId>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-
         <xsd.directory>${project.basedir}/target/generated-resources/xsd</xsd.directory>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.1</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.jvnet.jaxb2_commons</groupId>
             <artifactId>jaxb2-basics-runtime</artifactId>
@@ -28,19 +43,13 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>4.3.4.RELEASE</version>
+            <version>5.1.2.RELEASE</version>
             <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-oxm</artifactId>
-            <version>4.3.4.RELEASE</version>
+            <version>5.1.2.RELEASE</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -58,13 +67,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.25</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.25</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -73,23 +82,15 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.5.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
-                </plugin>
-                <plugin>
                     <groupId>org.jvnet.jaxb2.maven2</groupId>
                     <artifactId>maven-jaxb2-plugin</artifactId>
-                    <version>0.13.1</version>
+                    <version>0.14.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
-                        <generateBackupPoms>false</generateBackupPoms>
+                        <excludePackageNames>no.digipost.signature.api.xml</excludePackageNames>
+                        <detectOfflineLinks>false</detectOfflineLinks>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -99,7 +100,6 @@
                         <noticeTemplate>${project.basedir}/../src/notice/NOTICE.template</noticeTemplate>
                     </configuration>
                 </plugin>
-
             </plugins>
         </pluginManagement>
         <plugins>
@@ -124,57 +124,6 @@
                         <configuration>
                             <includeArtifactIds>signature-api-specification</includeArtifactIds>
                             <outputDirectory>${xsd.directory}</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <excludePackageNames>no.digipost.signature.api.xml.thirdparty.xmldsig</excludePackageNames>
-                    <additionalparam>-Xdoclint:-missing</additionalparam>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <includePom>true</includePom>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <bannedDependencies>
-                                    <excludes>
-                                        <exclude>commons-logging</exclude>
-                                    </excludes>
-                                    <searchTransitive>true</searchTransitive>
-                                </bannedDependencies>
-                            </rules>
                         </configuration>
                     </execution>
                 </executions>
@@ -243,13 +192,5 @@
 
         </plugins>
     </build>
-
-    <parent>
-        <groupId>no.digipost.signature</groupId>
-        <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.4-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>no.digipost</groupId>
+        <artifactId>digipost-open-super-pom</artifactId>
+        <version>2</version>
+    </parent>
+
     <name>Posten signering - API Specification</name>
     <description>Service description of Digipost's signature service.</description>
 
@@ -14,13 +22,18 @@
         <module>jaxb</module>
     </modules>
 
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
 
 	<build>
 		<pluginManagement>
             <plugins>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-help-plugin</artifactId>
@@ -35,17 +48,56 @@
                     <version>3.0.1</version>
                 </plugin>
                 <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>3.0.0-M2</version>
+                    <configuration>
+                        <rules>
+                            <requireMavenVersion>
+                                <!-- Maven 3.3.1 is needed for .mvn/maven.config to work
+                                     https://maven.apache.org/docs/3.3.1/release-notes.html -->
+                                <version>3.3.1</version>
+                            </requireMavenVersion>
+                            <bannedDependencies>
+                                <excludes>
+                                    <exclude>commons-logging</exclude>
+                                    <exclude>com.sun.xml.bind</exclude>
+                                </excludes>
+                                <searchTransitive>true</searchTransitive>
+                            </bannedDependencies>
+                        </rules>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jasig.maven</groupId>
                     <artifactId>maven-notice-plugin</artifactId>
-                    <version>1.0.6.1</version>
-                    <inherited>false</inherited>
+                    <version>1.1.0</version>
                     <configuration>
+                        <excludeOptional>true</excludeOptional>
+                        <excludeScopes>
+                            <excludeScope>test</excludeScope>
+                        </excludeScopes>
                         <noticeTemplate>${project.basedir}/src/notice/NOTICE.template</noticeTemplate>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.glassfish.jaxb</groupId>
+                            <artifactId>jaxb-runtime</artifactId>
+                            <version>2.3.1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>javax.xml.bind</groupId>
+                            <artifactId>jaxb-api</artifactId>
+                            <version>2.3.1</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>
@@ -72,28 +124,27 @@
                             <exclude>jaxb/*.xjb</exclude>
                             <exclude>integrasjon/**</exclude>
                             <exclude>docs/**</exclude>
+                            <exclude>.java-version</exclude>
+                            <exclude>.mvn/maven.config</exclude>
                         </excludes>
                     </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.3</version>
-                    <configuration>
-                        <generateBackupPoms>false</generateBackupPoms>
-                    </configuration>
+                    <version>2.7</version>
                 </plugin>
 			</plugins>
 		</pluginManagement>
@@ -124,23 +175,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireMavenVersion>
-                                    <version>3.0</version>
-                                </requireMavenVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
 	</build>
 
@@ -150,17 +184,5 @@
 		<url>https://github.com/digipost/signature-api-specification/</url>
 		<tag>HEAD</tag>
 	</scm>
-
-
-
-
-    <parent>
-        <groupId>no.digipost</groupId>
-        <artifactId>digipost-open-super-pom</artifactId>
-        <version>1</version>
-        <relativePath />
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
 
 </project>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -1,11 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>no.digipost.signature</groupId>
+        <artifactId>signature-api-specification-parent</artifactId>
+        <version>2.4-SNAPSHOT</version>
+    </parent>
+
+
     <name>Posten signering - API Schema</name>
 
 	<artifactId>signature-api-specification</artifactId>
-    <packaging>pom</packaging>
-
+    <properties>
+        <maven.main.skip>true</maven.main.skip>
+        <maven.test.skip>true</maven.test.skip>
+        <maven.source.skip>true</maven.source.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
 
 	<build>
         <resources>
@@ -59,14 +72,6 @@
 		</pluginManagement>
 		<plugins>
             <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals><goal>resources</goal></goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>
                 <executions>
@@ -75,44 +80,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
-                <executions>
-                    <execution>
-                        <goals><goal>jar</goal></goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.12</version>
-                <executions>
-                    <execution>
-                        <goals><goal>attach-artifact</goal></goals>
-                        <configuration>
-                            <artifacts>
-                                <artifact>
-                                    <file>target/${project.build.finalName}.jar</file>
-                                    <type>jar</type>
-                                </artifact>
-                            </artifacts>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
 		</plugins>
 	</build>
-
-
-
-    <parent>
-        <groupId>no.digipost.signature</groupId>
-        <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.4-SNAPSHOT</version>
-    </parent>
-
-    <modelVersion>4.0.0</modelVersion>
 
 </project>


### PR DESCRIPTION
To make the build work with both JDK 8 and 11 (still targets JDK 8 for
Java classfiles).

Change packaging type of schema-module from pom to jar, to be able to
update the maven-jar-plugin.