### PR TITLE
Be om ny redirect-url i direkteflyt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".travis"]
+	path = .travis
+	url = https://github.com/digipost/digipost-open-travis-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
-sudo: false
+dist: trusty
+language: java
+jdk:
+- oraclejdk8
+
 cache:
   directories:
-  - "$HOME/.m2/repository"
+  - $HOME/.m2
+
 env:
   global:
   - secure: Hqaf+a72V36nUhW8XYXiYZlex5+Nu6avS2a1oLugmIuy9hVS2TFeJ1tX1XEnCgsMtA/739UJL22513PTMpyGGNoKHNumrlMb4FRGzifr7zlDR3pnx1M5gJ2f0BZuL8J1ZNzRyUjXUHABclwLPThiKPAut4LVHSfdc1wF08IYJdgORmIPmvJqiWg6Kd/Bd6vKPYRkgIK/lI0TUUcwZjpAITgrBU33fU0k5z9JYu6AmrgqnnmQoipcV3dc4fItljHW/0vGwk8Tx1q3hq/1EtMnVOgamADXsTQS/hEMroPY0hB1TxAGR631NsqfJmkrjz3IDPtsMZflfmd2k/ZnQXaYCGiGxBURViRsNtgV5phGKF0w6+1THlDT+eT3ocAWg7ETnhp/T0CCrsUJJSBr8hFXXQ80Tgfxk9LBrywinWfjg7MvB6AFG5YGZ7Zw6MLbpdzFAuklxwd73Xv1I2/jRw0fN4IjO9PIWWKuRtvDYJRKm+qT1lpIpXk34TFpeiudAXu0T0ZKF5xsi6D8k60pxQLFHKieyWk0VAIdXb6xr576Mu6YGOTfNiKrW3ZONB/sZH3cZNez4FPKiEcCBVpjD5cPLOtuQAoIh22WAuTpr4zIsCfkKcmph74tm6JCHt6g1mFb9SRXsgjOs30C85FUE/PtBOoySUyQomPzN2AeRSRWcMg=
   - secure: TMIyQDIuJ8uya/4yh0wIwppN5i4kjPSCPMIzsNqHhIpMit6VIZBJMLYdH9AkzuSci8izdhHfPnPpS3SCKqKrxx97S2/ospZl1O+GnGy05HDk/voa6TLfJZ8l8swkhcFELtMBNAHr5wAvG+ExHIP6mEjY22j6xv122kWYz9tmBZBvm+pFhgkrLbQssvEmW06wqdotEMoroqwebtgYacyROetxJaIy8UZhsKfrOyH4FNlKzkZMe1Owsq9wAb3DdwNedxpFtaXz8nfhLYuDmW0YFGwHiahq6PvixXD6uw4em3SOgjeEzMf1UbG0uTWWnwZmTtZ0kbDYvYfLyHtMckfgUpu+Oxyhf0Jr/96J3uPG2NM/ImWF3TFj+dpznG8GZJfLQYNz7EACrMC/cENolbt709YfkRaK5SNRRlOYZNQg3zXD+cuANI7KHtbiSdiYTheaVIwcJ+qHhq3PdD7rnxG70llWK0AKDAsjoJ1KvVIg9EbTohOxlTzQWCjxM260gTlU5sHwjaikQMpcXtc4nzoGJbjaXUH7Vx8iZx3qbtKrReFK2xrdV1XMxbyj+QYBGCR5arqBTfaU9vH20rWltv0bJ+jhCHgochxDToqt9PRnpQVZvAhcOrsxsxHGJ94O6sJlc4feUB4y7lmqg8zWrbUHXok2nOVlSnVDAuWaODW5WIM=
 
-language: java
-jdk:
-- oraclejdk8
+install: true
 
-before_install:
-- echo "<settings><servers><server><id>sonatype-oss-nexus-snapshots</id><username>\${env.SONATYPE_USER}</username><password>\${env.SONATYPE_PASS}</password></server></servers></settings>" > ~/.m2/deploy-settings.xml
-
-install:
-- export mavenBuildGoal="$([[ ${TRAVIS_TAG} == '' ]] && echo deploy || echo verify)"
-- echo "Maven will ${mavenBuildGoal}"
-- mvn clean ${mavenBuildGoal} --settings ~/.m2/deploy-settings.xml
+before_script:
+  - cp .travis/maven.settings.xml ~/.m2/settings.xml
 
 script:
-- echo "no build script"
+  - mvn clean deploy --update-snapshots

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -16,13 +16,19 @@
         <xsd.directory>${project.basedir}/target/generated-resources/xsd</xsd.directory>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.5.0-M1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>2.1</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
@@ -59,9 +65,25 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>co.unruly</groupId>
+            <artifactId>java-8-matchers</artifactId>
+            <version>1.6</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.7-SNAPSHOT</version>
+        <version>2.7-RC1</version>
     </parent>
 
     <name>Posten signering - API JAXB Classes</name>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.1.5.RELEASE</version>
+            <version>5.1.7.RELEASE</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-oxm</artifactId>
-            <version>5.1.5.RELEASE</version>
+            <version>5.1.7.RELEASE</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.7-RC1</version>
+        <version>2.7-SNAPSHOT</version>
     </parent>
 
     <name>Posten signering - API JAXB Classes</name>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -165,12 +165,18 @@
                         <arg>-Xvalue-constructor</arg>
                         <arg>-Xfluent-api</arg>
                         <arg>-Xinheritance</arg>
+                        <arg>-Xannotate</arg>
                     </args>
                     <plugins>
                         <plugin>
                             <groupId>org.jvnet.jaxb2_commons</groupId>
                             <artifactId>jaxb2-basics</artifactId>
                             <version>0.12.0</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.jvnet.jaxb2_commons</groupId>
+                            <artifactId>jaxb2-basics-annotate</artifactId>
+                            <version>1.1.0</version>
                         </plugin>
                         <plugin>
                             <groupId>org.jvnet.jaxb2_commons</groupId>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -119,6 +119,7 @@
                     <configuration>
                         <excludePackageNames>no.digipost.signature.api.xml</excludePackageNames>
                         <detectOfflineLinks>false</detectOfflineLinks>
+                        <doclint>all,-missing,-html</doclint>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/jaxb/src/main/java/no/digipost/signature/jaxb/SignatureMarshalling.java
+++ b/jaxb/src/main/java/no/digipost/signature/jaxb/SignatureMarshalling.java
@@ -19,6 +19,8 @@ import no.digipost.signature.api.xml.XMLDirectSignatureJobManifest;
 import no.digipost.signature.api.xml.XMLDirectSignatureJobRequest;
 import no.digipost.signature.api.xml.XMLDirectSignatureJobResponse;
 import no.digipost.signature.api.xml.XMLDirectSignatureJobStatusResponse;
+import no.digipost.signature.api.xml.XMLDirectSignerResponse;
+import no.digipost.signature.api.xml.XMLDirectSignerUpdateRequest;
 import no.digipost.signature.api.xml.XMLError;
 import no.digipost.signature.api.xml.XMLPortalSignatureJobManifest;
 import no.digipost.signature.api.xml.XMLPortalSignatureJobRequest;
@@ -72,14 +74,14 @@ public final class SignatureMarshalling {
      * All classes necessary for a {@code JAXBContext} to handle marshalling <em>requests</em> to the Direct API.
      */
     public static Set<Class<?>> directApiJaxbClassesForRequests() {
-        return unionOf(commonJaxbClassesForRequests(), XMLDirectSignatureJobRequest.class, XMLDirectSignatureJobManifest.class);
+        return unionOf(commonJaxbClassesForRequests(), XMLDirectSignatureJobRequest.class, XMLDirectSignerUpdateRequest.class, XMLDirectSignatureJobManifest.class);
     }
 
     /**
      * All classes necessary for a {@code JAXBContext} to handle unmarshalling <em>responses</em> from the Direct API.
      */
     public static Set<Class<?>> directApiJaxbClassesForResponses() {
-        return unionOf(commonJaxbClassesForResponses(), XMLDirectSignatureJobResponse.class, XMLDirectSignatureJobStatusResponse.class);
+        return unionOf(commonJaxbClassesForResponses(), XMLDirectSignatureJobResponse.class, XMLDirectSignerResponse.class, XMLDirectSignatureJobStatusResponse.class);
     }
 
     /**

--- a/jaxb/src/main/jaxb/bindings.xjb
+++ b/jaxb/src/main/jaxb/bindings.xjb
@@ -19,9 +19,12 @@
 <bindings version="2.1"
           xmlns="http://java.sun.com/xml/ns/jaxb"
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
           xmlns:inheritance="http://jaxb2-commons.dev.java.net/basic/inheritance"
-          extensionBindingPrefixes="xjc">
+          xmlns:annox="http://annox.dev.java.net"
+          xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+          extensionBindingPrefixes="xjc annox">
 
     <globalBindings>
         <xjc:simple/>
@@ -78,6 +81,9 @@
     <bindings schemaLocation="../../../target/generated-resources/xsd/direct.xsd" node="/xs:schema">
         <bindings node="//xs:complexType[@name='direct-signer']">
             <inheritance:implements>no.digipost.signature.jaxb.XMLSigner</inheritance:implements>
+        </bindings>
+        <bindings node="//xs:complexType[@name='direct-signature-job-response']/*/xs:element[@name='redirect-url']">
+            <annox:annotateProperty>@java.lang.Deprecated</annox:annotateProperty>
         </bindings>
     </bindings>
 

--- a/jaxb/src/test/java/no/digipost/signature/xsd/SignatureApiSchemasTest.java
+++ b/jaxb/src/test/java/no/digipost/signature/xsd/SignatureApiSchemasTest.java
@@ -15,7 +15,7 @@
  */
 package no.digipost.signature.xsd;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -23,10 +23,10 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static java.lang.reflect.Modifier.isStatic;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 public class SignatureApiSchemasTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>2.7-SNAPSHOT</version>
+	<version>2.7-RC1</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -182,7 +182,7 @@
 		<connection>scm:git:git@github.com:digipost/signature-api-specification.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/signature-api-specification.git</developerConnection>
 		<url>https://github.com/digipost/signature-api-specification/</url>
-		<tag>HEAD</tag>
+		<tag>2.7-RC1</tag>
 	</scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>
-        <version>2</version>
+        <version>3</version>
     </parent>
 
     <name>Posten signering - API Specification</name>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-help-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
@@ -49,7 +49,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
@@ -131,7 +131,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>no.digipost.signature</groupId>
 	<artifactId>signature-api-specification-parent</artifactId>
-	<version>2.7-RC1</version>
+	<version>2.7-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -182,7 +182,7 @@
 		<connection>scm:git:git@github.com:digipost/signature-api-specification.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/signature-api-specification.git</developerConnection>
 		<url>https://github.com/digipost/signature-api-specification/</url>
-		<tag>2.7-RC1</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,8 @@
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>
-					<artifactId>license-maven-plugin</artifactId>
-					<version>3.0</version>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>3.0</version>
                     <configuration>
                         <header>src/license-header.txt</header>
                         <strictCheck>true</strictCheck>
@@ -118,7 +118,7 @@
                             <exclude>xsd/catalog.xml</exclude>
                             <exclude>examples/**/*</exclude>
                             <exclude>NOTICE</exclude>
-                            <exclude>LICENSE</exclude>
+                            <exclude>**/LICENSE</exclude>
                             <exclude>src/notice/NOTICE.template</exclude>
                             <exclude>src/notice/license-mappings.xml</exclude>
                             <exclude>jaxb/*.xjb</exclude>

--- a/schema/examples/direct/multiple_signers/response.xml
+++ b/schema/examples/direct/multiple_signers/response.xml
@@ -8,4 +8,10 @@
         https://signering.posten.no#/redirect/cwYjoZOX5jOc1BACfTdhuIPjWr4BzZ234PqHOgJj03o
     </redirect-url>
     <status-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/status</status-url>
+    <signing-url signer="123abc">
+        https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/1/signing-url
+    </signing-url>
+    <signing-url signer="10987654321">
+        https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/2/signing-url
+    </signing-url>
 </direct-signature-job-response>

--- a/schema/examples/direct/multiple_signers/response.xml
+++ b/schema/examples/direct/multiple_signers/response.xml
@@ -8,10 +8,13 @@
         https://signering.posten.no#/redirect/cwYjoZOX5jOc1BACfTdhuIPjWr4BzZ234PqHOgJj03o
     </redirect-url>
     <status-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/status</status-url>
-    <signing-url signer="123abc">
-        https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/1/signing-url
-    </signing-url>
-    <signing-url signer="10987654321">
-        https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/2/signing-url
-    </signing-url>
+    <signer>
+        <personal-identification-number>10987654321</personal-identification-number>
+        <redirect-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/1</redirect-url>
+    </signer>
+    <signer>
+        <signer-identifier>123abc</signer-identifier>
+        <redirect-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/2</redirect-url>
+    </signer>
+
 </direct-signature-job-response>

--- a/schema/examples/direct/multiple_signers/response.xml
+++ b/schema/examples/direct/multiple_signers/response.xml
@@ -2,19 +2,20 @@
 <direct-signature-job-response xmlns="http://signering.posten.no/schema/v1">
     <signature-job-id>1</signature-job-id>
     <redirect-url signer="123abc">
+        <!-- This element is deprecated -->
         https://signering.posten.no#/redirect/P1P-rdPK03Vf-z4NZb1mtDcExjpOzzVEkwal_F9FKm0
     </redirect-url>
     <redirect-url signer="10987654321">
+        <!-- This element is deprecated -->
         https://signering.posten.no#/redirect/cwYjoZOX5jOc1BACfTdhuIPjWr4BzZ234PqHOgJj03o
     </redirect-url>
     <status-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/status</status-url>
-    <signer>
+    <signer href="https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/1">
         <personal-identification-number>10987654321</personal-identification-number>
-        <redirect-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/1</redirect-url>
+        <redirect-url>https://signering.posten.no#/redirect/cwYjoZOX5jOc1BACfTdhuIPjWr4BzZ234PqHOgJj03o</redirect-url>
     </signer>
-    <signer>
+    <signer href="https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/2">
         <signer-identifier>123abc</signer-identifier>
-        <redirect-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/2</redirect-url>
+        <redirect-url>https://signering.posten.no#/redirect/P1P-rdPK03Vf-z4NZb1mtDcExjpOzzVEkwal_F9FKm0</redirect-url>
     </signer>
-
 </direct-signature-job-response>

--- a/schema/examples/direct/response.xml
+++ b/schema/examples/direct/response.xml
@@ -5,5 +5,8 @@
         https://signering.posten.no#/redirect/421e7ac38da1f81150cfae8a053cef62f9e7433ffd9395e5805e820980653657
     </redirect-url>
     <status-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/status</status-url>
-    <signing-url signer="12345678910">https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/1/signing-url</signing-url>
+    <signer>
+        <personal-identification-number>12345678910</personal-identification-number>
+        <redirect-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/1/redirect-url</redirect-url>
+    </signer>
 </direct-signature-job-response>

--- a/schema/examples/direct/response.xml
+++ b/schema/examples/direct/response.xml
@@ -5,4 +5,5 @@
         https://signering.posten.no#/redirect/421e7ac38da1f81150cfae8a053cef62f9e7433ffd9395e5805e820980653657
     </redirect-url>
     <status-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/status</status-url>
+    <signing-url signer="12345678910">https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/1/signing-url</signing-url>
 </direct-signature-job-response>

--- a/schema/examples/direct/response.xml
+++ b/schema/examples/direct/response.xml
@@ -2,11 +2,14 @@
 <direct-signature-job-response xmlns="http://signering.posten.no/schema/v1">
     <signature-job-id>1</signature-job-id>
     <redirect-url>
+        <!-- This element is deprecated -->
         https://signering.posten.no#/redirect/421e7ac38da1f81150cfae8a053cef62f9e7433ffd9395e5805e820980653657
     </redirect-url>
     <status-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/status</status-url>
-    <signer>
+    <signer href="https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/1">
         <personal-identification-number>12345678910</personal-identification-number>
-        <redirect-url>https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/1/redirect-url</redirect-url>
+        <redirect-url>
+            https://signering.posten.no#/redirect/421e7ac38da1f81150cfae8a053cef62f9e7433ffd9395e5805e820980653657
+        </redirect-url>
     </signer>
 </direct-signature-job-response>

--- a/schema/examples/direct/signer-response.xml
+++ b/schema/examples/direct/signer-response.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+    This is the state of one specific signer of a direct signature job. It is
+    the same type as the direct-signature-job-response/signer element of the
+    response from creating a new direct signature job.
+ -->
+<direct-signer-response xmlns="http://signering.posten.no/schema/v1"
+                        href="https://api.signering.posten.no/api/123456789/direct/signature-jobs/1/signers/1">
+    <personal-identification-number>12345678910</personal-identification-number>
+    <redirect-url>
+        https://signering.posten.no#/redirect/421e7ac38da1f81150cfae8a053cef62f9e7433ffd9395e5805e820980653657
+    </redirect-url>
+</direct-signer-response>

--- a/schema/examples/direct/signer-update-request.xml
+++ b/schema/examples/direct/signer-update-request.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+    This request is posted to a URL for the specific signer you want to update.
+    The URL is found in the href attribute for each signer in the response received
+    when creating the direct signature job.
+ -->
+<direct-signer-update-request xmlns="http://signering.posten.no/schema/v1">
+    <!-- For now, the only supported property to update is the redirect-url.
+         This is typically done if something fails when a signer attempts to sign,
+         and a new redirect-url is needed for retrying to sign. -->
+    <redirect-url />
+</direct-signer-update-request>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.7-SNAPSHOT</version>
+        <version>2.7-RC1</version>
     </parent>
 
 

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>no.digipost.signature</groupId>
         <artifactId>signature-api-specification-parent</artifactId>
-        <version>2.7-RC1</version>
+        <version>2.7-SNAPSHOT</version>
     </parent>
 
 

--- a/schema/xsd/common.xsd
+++ b/schema/xsd/common.xsd
@@ -48,6 +48,16 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:complexType name="accessible-by-url" abstract="true">
+        <xs:attribute name="href" type="url" use="required" >
+            <xs:annotation>
+                <xs:documentation>The URL for this entity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="empty-element" final="#all" />
+
     <xs:simpleType name="personal-identification-number">
         <xs:restriction base="xs:string">
             <xs:pattern value="[0-9]{11}"/>

--- a/schema/xsd/direct.xsd
+++ b/schema/xsd/direct.xsd
@@ -206,8 +206,9 @@ for the default queue.
                     <xs:element name="redirect-url" type="url" minOccurs="1" maxOccurs="1">
                         <xs:annotation>
                             <xs:documentation>
-                                The signer's browser should be redirected here to the signing. This URL can only be used once, and
-                                a request for a new URL must be made to for instance retry a failing document signing.
+                                The signer's browser should be redirected here to sign the document. This URL can only
+                                be used once, and a request for a new URL must be made to for instance retry a failing
+                                document signing.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>

--- a/schema/xsd/direct.xsd
+++ b/schema/xsd/direct.xsd
@@ -185,6 +185,8 @@ for the default queue.
         </xs:complexType>
     </xs:element>
 
+    <xs:element name="signer-specific-url" type="signer-specific-url" />
+
     <xs:complexType name="signer-specific-url">
         <xs:simpleContent>
             <xs:extension base="url">

--- a/schema/xsd/direct.xsd
+++ b/schema/xsd/direct.xsd
@@ -185,7 +185,7 @@ for the default queue.
                     <xs:documentation>DEPRECATED. Redirect-URL is part of each signer.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="status-url" minOccurs="0" maxOccurs="1" type="url"/>
+            <xs:element name="status-url" minOccurs="0" maxOccurs="1" type="url" />
             <xs:element name="signer" minOccurs="1" maxOccurs="10" type="direct-signer-response" />
         </xs:sequence>
     </xs:complexType>
@@ -194,16 +194,39 @@ for the default queue.
     <xs:element name="direct-signer-response" type="direct-signer-response" />
 
     <xs:complexType name="direct-signer-response">
-        <xs:sequence>
-            <xs:choice>
-                <xs:element name="signer-identifier" minOccurs="1" maxOccurs="1"
-                            type="signer-identifier"/>
-                <xs:element name="personal-identification-number" minOccurs="1" maxOccurs="1"
-                            type="personal-identification-number"/>
-            </xs:choice>
-            <xs:element name="redirect-url" type="url"/>
-        </xs:sequence>
+        <xs:complexContent>
+            <xs:extension base="accessible-by-url">
+                <xs:sequence>
+                    <xs:choice>
+                        <xs:element name="signer-identifier" minOccurs="1" maxOccurs="1"
+                                    type="signer-identifier" />
+                        <xs:element name="personal-identification-number" minOccurs="1" maxOccurs="1"
+                                    type="personal-identification-number" />
+                    </xs:choice>
+                    <xs:element name="redirect-url" type="url" minOccurs="1" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The signer's browser should be redirected here to the signing. This URL can only be used once, and
+                                a request for a new URL must be made to for instance retry a failing document signing.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
+
+    <xs:element name="direct-signer-update-request">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="redirect-url" minOccurs="1" maxOccurs="1" type="empty-element">
+                    <xs:annotation>
+                        <xs:documentation>The presence of this element specifies you want to update the redirect-url for the signer.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
 
     <xs:complexType name="signer-specific-url">
         <xs:simpleContent>

--- a/schema/xsd/direct.xsd
+++ b/schema/xsd/direct.xsd
@@ -174,19 +174,36 @@ for the default queue.
     </xs:simpleType>
 
 
-    <xs:element name="direct-signature-job-response">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="reference" minOccurs="0" maxOccurs="1" type="signature-job-reference"/>
-                <xs:element name="signature-job-id" minOccurs="1" maxOccurs="1" type="signature-job-id"/>
-                <xs:element name="redirect-url" minOccurs="1" maxOccurs="10" type="signer-specific-url" />
-                <xs:element name="status-url" minOccurs="0" maxOccurs="1" type="url"/>
-                <xs:element name="signing-url" minOccurs="1" maxOccurs="10" type="signer-specific-url" />
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
+    <xs:element name="direct-signature-job-response" type="direct-signature-job-response" />
 
-    <xs:element name="signer-specific-url" type="signer-specific-url" />
+    <xs:complexType name="direct-signature-job-response">
+        <xs:sequence>
+            <xs:element name="reference" minOccurs="0" maxOccurs="1" type="signature-job-reference"/>
+            <xs:element name="signature-job-id" minOccurs="1" maxOccurs="1" type="signature-job-id"/>
+            <xs:element name="redirect-url" minOccurs="1" maxOccurs="10" type="signer-specific-url" >
+                <xs:annotation>
+                    <xs:documentation>DEPRECATED. Redirect-URL is part of each signer.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="status-url" minOccurs="0" maxOccurs="1" type="url"/>
+            <xs:element name="signer" minOccurs="1" maxOccurs="10" type="direct-signer-response" />
+        </xs:sequence>
+    </xs:complexType>
+
+
+    <xs:element name="direct-signer-response" type="direct-signer-response" />
+
+    <xs:complexType name="direct-signer-response">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="signer-identifier" minOccurs="1" maxOccurs="1"
+                            type="signer-identifier"/>
+                <xs:element name="personal-identification-number" minOccurs="1" maxOccurs="1"
+                            type="personal-identification-number"/>
+            </xs:choice>
+            <xs:element name="redirect-url" type="url"/>
+        </xs:sequence>
+    </xs:complexType>
 
     <xs:complexType name="signer-specific-url">
         <xs:simpleContent>

--- a/schema/xsd/direct.xsd
+++ b/schema/xsd/direct.xsd
@@ -181,6 +181,7 @@ for the default queue.
                 <xs:element name="signature-job-id" minOccurs="1" maxOccurs="1" type="signature-job-id"/>
                 <xs:element name="redirect-url" minOccurs="1" maxOccurs="10" type="signer-specific-url" />
                 <xs:element name="status-url" minOccurs="0" maxOccurs="1" type="url"/>
+                <xs:element name="signing-url" minOccurs="1" maxOccurs="10" type="signer-specific-url" />
             </xs:sequence>
         </xs:complexType>
     </xs:element>


### PR DESCRIPTION
En avsender skal kunne be om ny URL slik at en undertegner kan forsøke å signere flere ganger innenfor samme jobb.

Innfører en ny XSD-type for undertegner: `direct-signer-response`, som returneres i jobb-responser, samt ved oppdatering av en enkelt-undertegner. 🐇