### PR TITLE
Adds title and description to job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build with Maven
-        run: mvn -B package --no-transfer-progress --file pom.xml
+        run: mvn -B verify --show-version --no-transfer-progress
 
   deploy:
     runs-on: ubuntu-latest

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.5.2</version>
+                <version>5.7.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.4.3</version>
+            <version>3.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -145,7 +145,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.2.0</version>
                     <configuration>
                         <excludePackageNames>no.digipost.signature.api.xml.*</excludePackageNames>
                         <detectOfflineLinks>false</detectOfflineLinks>
@@ -245,7 +245,7 @@
                         <plugin>
                             <groupId>org.apache.cxf.xjcplugins</groupId>
                             <artifactId>cxf-xjc-javadoc</artifactId>
-                            <version>3.3.0</version>
+                            <version>3.3.1</version>
                         </plugin>
                         <plugin>
                             <groupId>com.github.jaxb-xew-plugin</groupId>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -25,6 +25,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>5.3.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -55,13 +62,11 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.1.9.RELEASE</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-oxm</artifactId>
-            <version>5.2.9.RELEASE</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -99,9 +104,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.javers</groupId>
+            <artifactId>javers-core</artifactId>
+            <version>5.14.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>digg</artifactId>
-            <version>0.24</version>
+            <version>0.25</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -114,6 +125,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.30</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ws</groupId>
+            <artifactId>spring-xml</artifactId>
+            <version>3.0.10.RELEASE</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jaxb/src/main/java/no/digipost/signature/api/xml/JobInformation.java
+++ b/jaxb/src/main/java/no/digipost/signature/api/xml/JobInformation.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.api.xml;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public final class JobInformation {
+
+    private final String title;
+    private final Optional<String> nonSensitiveTitle;
+    private final Optional<String> description;
+
+    public JobInformation(String title, String nonSensitiveTitle, String description) {
+        this.title = requireNonNull(title, "title");
+        this.nonSensitiveTitle = Optional.ofNullable(nonSensitiveTitle);
+        this.description = Optional.ofNullable(description);
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Optional<String> getNonSensitiveTitle() {
+        return nonSensitiveTitle;
+    }
+
+    public Optional<String> getDescription() {
+        return description;
+    }
+
+}

--- a/jaxb/src/main/java/no/digipost/signature/api/xml/MultipleDocumentsManifestWithLegacySingledDocumentSupport.java
+++ b/jaxb/src/main/java/no/digipost/signature/api/xml/MultipleDocumentsManifestWithLegacySingledDocumentSupport.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.api.xml;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+interface MultipleDocumentsManifestWithLegacySingleDocumentSupport extends XMLManifest {
+
+    @Override
+    @SuppressWarnings("deprecation")
+    default JobInformation getJobInformation() {
+        no.digipost.signature.api.xml.legacy.XMLLegacyDocument singleDocument = getDocument();
+        if (singleDocument != null) {
+            return new JobInformation(singleDocument.getTitle(), singleDocument.getNonsensitiveTitle(), singleDocument.getDescription());
+        } else {
+            return new JobInformation(getTitle(), getNonsensitiveTitle(), getDescription());
+        }
+    }
+
+    @Override
+    default List<? extends XMLDocument> getDocumentsToSign() {
+        @SuppressWarnings("deprecation")
+        XMLDocument singleDocument = getDocument();
+        return singleDocument != null ? asList(singleDocument) : getDocuments();
+    }
+
+    List<? extends XMLDocument> getDocuments();
+
+    String getTitle();
+
+    String getDescription();
+
+    String getNonsensitiveTitle();
+
+}

--- a/jaxb/src/main/java/no/digipost/signature/api/xml/SingleDocumentManifest.java
+++ b/jaxb/src/main/java/no/digipost/signature/api/xml/SingleDocumentManifest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.api.xml;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+interface SingleDocumentManifest extends XMLManifest {
+
+    @SuppressWarnings("deprecation")
+    default String getTitle() {
+        return getDocument().getTitle();
+    }
+
+    @SuppressWarnings("deprecation")
+    default String getDescription() {
+        return getDocument().getDescription();
+    }
+
+    @Override
+    default JobInformation getJobInformation() {
+        return new JobInformation(getTitle(), null, getDescription());
+    }
+
+    @SuppressWarnings("deprecation")
+    default List<? extends XMLDocument> getDocuments() {
+        return asList(getDocument());
+    }
+
+    @Override
+    default List<? extends XMLDocument> getDocumentsToSign() {
+        return getDocuments();
+    }
+}

--- a/jaxb/src/main/java/no/digipost/signature/api/xml/XMLDocument.java
+++ b/jaxb/src/main/java/no/digipost/signature/api/xml/XMLDocument.java
@@ -18,6 +18,7 @@ package no.digipost.signature.api.xml;
 public interface XMLDocument {
 
 	String getTitle();
+	String getDescription();
 	XMLHref getHref();
 	String getMime();
 

--- a/jaxb/src/main/java/no/digipost/signature/api/xml/XMLDocument.java
+++ b/jaxb/src/main/java/no/digipost/signature/api/xml/XMLDocument.java
@@ -18,7 +18,6 @@ package no.digipost.signature.api.xml;
 public interface XMLDocument {
 
 	String getTitle();
-	String getDescription();
 	XMLHref getHref();
 	String getMime();
 

--- a/jaxb/src/main/java/no/digipost/signature/api/xml/XMLManifest.java
+++ b/jaxb/src/main/java/no/digipost/signature/api/xml/XMLManifest.java
@@ -15,15 +15,19 @@
  */
 package no.digipost.signature.api.xml;
 
+import no.digipost.signature.api.xml.legacy.XMLLegacyDocument;
+
 import java.util.List;
 
+@SuppressWarnings("deprecation")
 public interface XMLManifest {
 
-    String getTitle();
+    JobInformation getJobInformation();
 
-    String getDescription();
+    List<? extends XMLDocument> getDocumentsToSign();
 
-    List<? extends XMLDocument> getDocuments();
+    @Deprecated
+    XMLLegacyDocument getDocument();
 
     XMLAuthenticationLevel getRequiredAuthentication();
 

--- a/jaxb/src/main/java/no/digipost/signature/api/xml/XMLManifest.java
+++ b/jaxb/src/main/java/no/digipost/signature/api/xml/XMLManifest.java
@@ -19,10 +19,14 @@ import java.util.List;
 
 public interface XMLManifest {
 
-	List<? extends XMLDocument> getDocuments();
+    String getTitle();
 
-	XMLAuthenticationLevel getRequiredAuthentication();
+    String getDescription();
 
-	List<? extends XMLSigner> getSigners();
+    List<? extends XMLDocument> getDocuments();
+
+    XMLAuthenticationLevel getRequiredAuthentication();
+
+    List<? extends XMLSigner> getSigners();
 
 }

--- a/jaxb/src/main/java/no/digipost/signature/api/xml/legacy/XMLLegacyDocument.java
+++ b/jaxb/src/main/java/no/digipost/signature/api/xml/legacy/XMLLegacyDocument.java
@@ -13,12 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package no.digipost.signature.api.xml;
+package no.digipost.signature.api.xml.legacy;
 
-public interface XMLDocument {
+import no.digipost.signature.api.xml.XMLDocument;
 
-	String getTitle();
-	XMLHref getHref();
-	String getMime();
+@Deprecated
+public interface XMLLegacyDocument extends XMLDocument {
+
+    String getDescription();
+
+    default String getNonsensitiveTitle() {
+        return null;
+    }
 
 }

--- a/jaxb/src/main/jaxb/bindings.xjb
+++ b/jaxb/src/main/jaxb/bindings.xjb
@@ -58,6 +58,7 @@
     <bindings schemaLocation="../../../target/generated-resources/xsd/portal.xsd" node="/xs:schema">
         <bindings node="//xs:element[@name='portal-signature-job-manifest']/xs:complexType">
             <inheritance:implements>no.digipost.signature.api.xml.XMLManifest</inheritance:implements>
+            <inheritance:implements>no.digipost.signature.api.xml.MultipleDocumentsManifestWithLegacySingleDocumentSupport</inheritance:implements>
         </bindings>
         <bindings node="//xs:complexType[@name='portal-document']">
             <inheritance:implements>no.digipost.signature.api.xml.XMLDocument</inheritance:implements>
@@ -72,12 +73,25 @@
         </bindings>
     </bindings>
 
+    <bindings schemaLocation="../../../target/generated-resources/xsd/portal-legacy.xsd" node="/xs:schema">
+        <bindings node="//xs:complexType[@name='legacy-portal-document']">
+            <inheritance:implements>no.digipost.signature.api.xml.legacy.XMLLegacyDocument</inheritance:implements>
+            <bindings node="xs:attribute[@name='href']">
+                <property>
+                    <baseType name="no.digipost.signature.api.xml.XMLHref" />
+                </property>
+            </bindings>
+        </bindings>
+    </bindings>
+
     <bindings schemaLocation="../../../target/generated-resources/xsd/direct.xsd" node="/xs:schema">
         <bindings node="//xs:element[@name='direct-signature-job-manifest']/xs:complexType">
             <inheritance:implements>no.digipost.signature.api.xml.XMLManifest</inheritance:implements>
+            <inheritance:implements>no.digipost.signature.api.xml.SingleDocumentManifest</inheritance:implements>
         </bindings>
         <bindings node="//xs:complexType[@name='direct-document']">
             <inheritance:implements>no.digipost.signature.api.xml.XMLDocument</inheritance:implements>
+            <inheritance:implements>no.digipost.signature.api.xml.legacy.XMLLegacyDocument</inheritance:implements>
             <bindings node="xs:attribute[@name='href']">
                 <property>
                     <baseType name="no.digipost.signature.api.xml.XMLHref" />

--- a/jaxb/src/main/jaxb/xew-control.properties
+++ b/jaxb/src/main/jaxb/xew-control.properties
@@ -17,5 +17,6 @@
 # Exclude _all_ candidate types
 /.*/=exclude
 
-# … except XMLPortalSigners
+# except:
 no.digipost.signature.api.xml.XMLPortalSigners=include
+no.digipost.signature.api.xml.XMLPortalSignatureJobManifest.XMLDocuments=include

--- a/jaxb/src/test/java/no/digipost/signature/api/xml/XMLDirectSignatureJobTest.java
+++ b/jaxb/src/test/java/no/digipost/signature/api/xml/XMLDirectSignatureJobTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.api.xml;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static co.unruly.matchers.Java8Matchers.where;
+import static co.unruly.matchers.OptionalMatchers.contains;
+import static co.unruly.matchers.OptionalMatchers.empty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.is;
+
+class XMLDirectSignatureJobTest {
+
+    @Test
+    void adaptSingularDocumentManifestToMultipleDocumentApi() {
+        XMLDirectDocument document = new XMLDirectDocument("title", "description", XMLHref.of("href"), "application/pdf");
+        XMLDirectSignatureJobManifest manifest = new XMLDirectSignatureJobManifest().withDocument(document);
+        assertThat(manifest, where(XMLManifest::getDocumentsToSign, Matchers.contains(document)));
+        assertThat(manifest.getJobInformation(), where(JobInformation::getTitle, both(is("title")).and(is(manifest.getDocument().getTitle()))));
+        assertThat(manifest.getJobInformation(), where(JobInformation::getNonSensitiveTitle, empty()));
+        assertThat(manifest.getJobInformation(), where(JobInformation::getDescription, both(contains("description")).and(contains(manifest.getDocument().getDescription()))));
+    }
+
+}

--- a/jaxb/src/test/java/no/digipost/signature/api/xml/XMLPortalSignatureJobTest.java
+++ b/jaxb/src/test/java/no/digipost/signature/api/xml/XMLPortalSignatureJobTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.api.xml;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static co.unruly.matchers.Java8Matchers.where;
+import static co.unruly.matchers.OptionalMatchers.contains;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+class XMLPortalSignatureJobTest {
+
+    @Test
+    void viewLegacySingularDocumentManifestAsMultipleDocumentsManifest() {
+        XMLLegacyPortalDocument document = new XMLLegacyPortalDocument("title", "non-sensitive title", "description", XMLHref.of("href"), "application/pdf");
+        XMLPortalSignatureJobManifest manifest = new XMLPortalSignatureJobManifest().withDocument(document);
+        assertThat(manifest, where(XMLManifest::getDocumentsToSign, Matchers.contains(document)));
+        assertThat(manifest.getJobInformation(), where(JobInformation::getTitle, both(is("title")).and(is(manifest.getDocument().getTitle()))));
+        assertThat(manifest.getJobInformation(), where(JobInformation::getNonSensitiveTitle, contains("non-sensitive title")));
+        assertThat(manifest.getJobInformation(), where(JobInformation::getDescription, both(contains("description")).and(contains(manifest.getDocument().getDescription()))));
+    }
+
+    @Test
+    void multipleDocumentsManifest() {
+        XMLPortalDocument document = new XMLPortalDocument("document title", XMLHref.of("href"), "application/pdf");
+        XMLPortalSignatureJobManifest manifest = new XMLPortalSignatureJobManifest()
+                .withTitle("title").withNonsensitiveTitle("non-sensitive title").withDescription("description")
+                .withDocuments(document);
+        assertThat(manifest, where(XMLManifest::getDocumentsToSign, Matchers.contains(document)));
+        assertThat(manifest.getJobInformation(), where(JobInformation::getTitle, is("title")));
+        assertThat(manifest.getJobInformation(), where(JobInformation::getNonSensitiveTitle, contains("non-sensitive title")));
+        assertThat(manifest.getJobInformation(), where(JobInformation::getDescription, contains("description")));
+        assertThat(manifest, where(XMLPortalSignatureJobManifest::getDocument, nullValue()));
+    }
+
+
+}

--- a/jaxb/src/test/java/no/digipost/signature/jaxb/spring/MarshallingMatchers.java
+++ b/jaxb/src/test/java/no/digipost/signature/jaxb/spring/MarshallingMatchers.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.jaxb.spring;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.javers.core.diff.Diff;
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
+import org.springframework.xml.transform.StringSource;
+
+import javax.xml.transform.stream.StreamResult;
+
+import java.io.CharArrayWriter;
+
+import static no.digipost.DiggBase.friendlyName;
+import static no.digipost.DiggExceptions.exceptionNameAndMessage;
+import static org.javers.core.JaversBuilder.javers;
+
+final class MarshallingMatchers {
+    private final Jaxb2Marshaller marshaller;
+
+    public MarshallingMatchers(Jaxb2Marshaller marshaller) {
+        this.marshaller = marshaller;
+    }
+
+
+    public <T> Matcher<T> marshallsToXmlAndUnmarshallsBackToJava() {
+        return new TypeSafeDiagnosingMatcher<T>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("translates to XML and back to Java");
+            }
+
+            @Override
+            protected boolean matchesSafely(T item, Description mismatchDescription) {
+                try (CharArrayWriter xmlWriter = new CharArrayWriter())  {
+                    try {
+                        marshaller.marshal(item, new StreamResult(xmlWriter));
+                    } catch (Exception e) {
+                        mismatchDescription
+                            .appendText("Unable to marshall ").appendValue(item).appendText(" to XML, because ")
+                            .appendText(exceptionNameAndMessage(e));
+                        return false;
+                    }
+                    String xml = xmlWriter.toString();
+                    Object unmarshalled;
+                    try {
+                        unmarshalled = marshaller.unmarshal(new StringSource(xml));
+                    } catch (Exception e) {
+                        mismatchDescription
+                            .appendValue(item).appendText(" marshalled successfully to XML:\n").appendText(xml)
+                            .appendText("\nbut was unable to unmarshall back to ").appendText(friendlyName(item.getClass()))
+                            .appendText(", because ").appendText(exceptionNameAndMessage(e));
+                            return false;
+                    }
+
+                    Diff diff = javers().build().compare(unmarshalled, item);
+                    if (!diff.hasChanges()) {
+                        return true;
+                    } else {
+                        mismatchDescription
+                            .appendValue("When marshalling ").appendValue(item).appendText("\nto XML:\n").appendText(xml)
+                            .appendText("\nand back, the resulting ").appendText(friendlyName(unmarshalled.getClass()))
+                            .appendText(" differed from the expected object:\n").appendValue(diff);
+                        return false;
+                    }
+                }
+            }
+
+        };
+    }
+
+
+}

--- a/jaxb/src/test/java/no/digipost/signature/jaxb/spring/MarshallingMatchers.java
+++ b/jaxb/src/test/java/no/digipost/signature/jaxb/spring/MarshallingMatchers.java
@@ -18,6 +18,7 @@ package no.digipost.signature.jaxb.spring;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.javers.core.Javers;
 import org.javers.core.diff.Diff;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.xml.transform.StringSource;
@@ -31,10 +32,13 @@ import static no.digipost.DiggExceptions.exceptionNameAndMessage;
 import static org.javers.core.JaversBuilder.javers;
 
 final class MarshallingMatchers {
+
     private final Jaxb2Marshaller marshaller;
+    private final Javers javers;
 
     public MarshallingMatchers(Jaxb2Marshaller marshaller) {
         this.marshaller = marshaller;
+        this.javers = javers().build();
     }
 
 
@@ -69,7 +73,7 @@ final class MarshallingMatchers {
                             return false;
                     }
 
-                    Diff diff = javers().build().compare(unmarshalled, item);
+                    Diff diff = javers.compare(unmarshalled, item);
                     if (!diff.hasChanges()) {
                         return true;
                     } else {

--- a/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
+++ b/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
@@ -42,10 +42,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
-import java.util.Collections;
 
 import static co.unruly.matchers.Java8Matchers.where;
+import static java.util.Arrays.asList;
 import static no.digipost.signature.api.xml.XMLAuthenticationLevel.FOUR;
 import static no.digipost.signature.api.xml.XMLAuthenticationLevel.THREE;
 import static no.digipost.signature.api.xml.XMLDirectSignerStatusValue.SIGNED;
@@ -68,7 +67,7 @@ public class SignatureJaxb2MarshallerTest {
         XMLSender sender = new XMLSender().withOrganizationNumber("123456789");
         XMLPortalSigner portalSigner = new XMLPortalSigner().withPersonalIdentificationNumber("12345678910").withNotificationsUsingLookup(new XMLNotificationsUsingLookup().withEmail(new XMLEnabled()));
         XMLDirectSigner directSigner = new XMLDirectSigner().withPersonalIdentificationNumber("12345678910");
-        XMLPortalDocument portalDocument = new XMLPortalDocument("Title", null, null, XMLHref.of("document.pdf"), "application/pdf");
+        XMLPortalDocument portalDocument = new XMLPortalDocument("Title", XMLHref.of("document.pdf"), "application/pdf");
         XMLDirectDocument directDocument = new XMLDirectDocument("Title", null, XMLHref.of("document.pdf"), "application/pdf");
         XMLExitUrls exitUrls = new XMLExitUrls()
                 .withCompletionUrl(URI.create("http://localhost/signed"))
@@ -76,13 +75,13 @@ public class SignatureJaxb2MarshallerTest {
                 .withErrorUrl(URI.create("http://localhost/failed"));
 
         XMLDirectSignatureJobRequest directJob = new XMLDirectSignatureJobRequest("123abc", exitUrls, null, null);
-        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Collections.singletonList(directSigner), sender, "Title", "Message", Collections.singletonList(directDocument), THREE, PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
+        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(asList(directSigner), sender, directDocument, THREE, PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
 
         marshaller.marshal(directJob, new StreamResult(new ByteArrayOutputStream()));
         marshaller.marshal(directManifest, new StreamResult(new ByteArrayOutputStream()));
 
         XMLPortalSignatureJobRequest portalJob = new XMLPortalSignatureJobRequest("123abc", null);
-        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Collections.singletonList(portalSigner), sender, "Title", "Non-sensitive title", "Message", Collections.singletonList(portalDocument), FOUR, new XMLAvailability().withActivationTime(ZonedDateTime.now()), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
+        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(asList(portalSigner), sender, null, "Title", "Non-sensitive title", "Message", asList(portalDocument), FOUR, new XMLAvailability().withActivationTime(ZonedDateTime.now()), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
         marshaller.marshal(portalJob, new StreamResult(new ByteArrayOutputStream()));
         marshaller.marshal(portalManifest, new StreamResult(new ByteArrayOutputStream()));
     }
@@ -107,11 +106,11 @@ public class SignatureJaxb2MarshallerTest {
         XMLSender sender = new XMLSender().withOrganizationNumber("123456789");
         XMLPortalSigner portalSigner = new XMLPortalSigner().withPersonalIdentificationNumber("12345678910");
         XMLDirectSigner directSigner = new XMLDirectSigner().withPersonalIdentificationNumber("12345678910");
-        XMLPortalDocument portalDocument = new XMLPortalDocument("Title", null, null, null, "application/pdf");
+        XMLPortalDocument portalDocument = new XMLPortalDocument("Title", null, "application/pdf");
         XMLDirectDocument directDocument = new XMLDirectDocument("Title", null, null, "application/pdf");
 
-        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Arrays.asList(directSigner), sender, "Title", "Description", Collections.singletonList(directDocument), FOUR, PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
-        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Arrays.asList(portalSigner), sender, "Title", "nonsensitive title", "Description", Collections.singletonList(portalDocument) , FOUR, new XMLAvailability(), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
+        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(asList(directSigner), sender, directDocument, FOUR, PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
+        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(asList(portalSigner), sender, null, "Title", "nonsensitive title", "Description", asList(portalDocument) , FOUR, new XMLAvailability(), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
 
 
         MarshallingFailureException directManifestMarshallingFailure =

--- a/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
+++ b/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
@@ -145,7 +145,7 @@ public class SignatureJaxb2MarshallerTest {
         XMLDirectSignatureJobStatusResponse unmarshalled;
         try (InputStream responseWithUnknownElement = getClass().getResourceAsStream("/xml/direct_signature_job_response_with_unexpected_element.xml")) {
             unmarshalled = (XMLDirectSignatureJobStatusResponse) SignatureJaxb2Marshaller.ForResponsesOfAllApis.singleton()
-                    .unmarshal(new StreamSource(getClass().getResourceAsStream("/xml/direct_signature_job_response_with_unexpected_element.xml")));
+                    .unmarshal(new StreamSource(responseWithUnknownElement));
         }
 
         assertThat(unmarshalled, where(XMLDirectSignatureJobStatusResponse::getSignatureJobId, is(1L)));

--- a/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
+++ b/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
@@ -68,21 +68,21 @@ public class SignatureJaxb2MarshallerTest {
         XMLSender sender = new XMLSender().withOrganizationNumber("123456789");
         XMLPortalSigner portalSigner = new XMLPortalSigner().withPersonalIdentificationNumber("12345678910").withNotificationsUsingLookup(new XMLNotificationsUsingLookup().withEmail(new XMLEnabled()));
         XMLDirectSigner directSigner = new XMLDirectSigner().withPersonalIdentificationNumber("12345678910");
-        XMLPortalDocument portalDocument = new XMLPortalDocument("Title", "Non-sensitive title", "Message", XMLHref.of("document.pdf"), "application/pdf");
-        XMLDirectDocument directDocument = new XMLDirectDocument("Title", "Message", XMLHref.of("document.pdf"), "application/pdf");
+        XMLPortalDocument portalDocument = new XMLPortalDocument("Title", null, null, XMLHref.of("document.pdf"), "application/pdf");
+        XMLDirectDocument directDocument = new XMLDirectDocument("Title", null, XMLHref.of("document.pdf"), "application/pdf");
         XMLExitUrls exitUrls = new XMLExitUrls()
                 .withCompletionUrl(URI.create("http://localhost/signed"))
                 .withRejectionUrl(URI.create("http://localhost/rejected"))
                 .withErrorUrl(URI.create("http://localhost/failed"));
 
         XMLDirectSignatureJobRequest directJob = new XMLDirectSignatureJobRequest("123abc", exitUrls, null, null);
-        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Collections.singletonList(directSigner), sender, Collections.singletonList(directDocument), THREE, PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
+        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Collections.singletonList(directSigner), sender, "Title", "Message", Collections.singletonList(directDocument), THREE, PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
 
         marshaller.marshal(directJob, new StreamResult(new ByteArrayOutputStream()));
         marshaller.marshal(directManifest, new StreamResult(new ByteArrayOutputStream()));
 
         XMLPortalSignatureJobRequest portalJob = new XMLPortalSignatureJobRequest("123abc", null);
-        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Collections.singletonList(portalSigner), sender, Collections.singletonList(portalDocument), FOUR, new XMLAvailability().withActivationTime(ZonedDateTime.now()), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
+        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Collections.singletonList(portalSigner), sender, "Title", "Non-sensitive title", "Message", Collections.singletonList(portalDocument), FOUR, new XMLAvailability().withActivationTime(ZonedDateTime.now()), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
         marshaller.marshal(portalJob, new StreamResult(new ByteArrayOutputStream()));
         marshaller.marshal(portalManifest, new StreamResult(new ByteArrayOutputStream()));
     }
@@ -107,11 +107,11 @@ public class SignatureJaxb2MarshallerTest {
         XMLSender sender = new XMLSender().withOrganizationNumber("123456789");
         XMLPortalSigner portalSigner = new XMLPortalSigner().withPersonalIdentificationNumber("12345678910");
         XMLDirectSigner directSigner = new XMLDirectSigner().withPersonalIdentificationNumber("12345678910");
-        XMLPortalDocument portalDocument = new XMLPortalDocument("Title", "nonsensitive title", "Description", null, "application/pdf");
-        XMLDirectDocument directDocument = new XMLDirectDocument("Title", "Description", null, "application/pdf");
+        XMLPortalDocument portalDocument = new XMLPortalDocument("Title", null, null, null, "application/pdf");
+        XMLDirectDocument directDocument = new XMLDirectDocument("Title", null, null, "application/pdf");
 
-        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Arrays.asList(directSigner), sender, Collections.singletonList(directDocument), FOUR, PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
-        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Arrays.asList(portalSigner), sender, Collections.singletonList(portalDocument) , FOUR, new XMLAvailability(), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
+        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Arrays.asList(directSigner), sender, "Title", "Description", Collections.singletonList(directDocument), FOUR, PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
+        XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(Arrays.asList(portalSigner), sender, "Title", "nonsensitive title", "Description", Collections.singletonList(portalDocument) , FOUR, new XMLAvailability(), PERSONAL_IDENTIFICATION_NUMBER_AND_NAME);
 
 
         MarshallingFailureException directManifestMarshallingFailure =

--- a/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
+++ b/jaxb/src/test/java/no/digipost/signature/jaxb/spring/SignatureJaxb2MarshallerTest.java
@@ -47,6 +47,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import static co.unruly.matchers.Java8Matchers.where;
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.Arrays.asList;
 import static no.digipost.signature.api.xml.XMLAuthenticationLevel.FOUR;
 import static no.digipost.signature.api.xml.XMLAuthenticationLevel.THREE;
@@ -132,7 +133,7 @@ class SignatureJaxb2MarshallerTest {
         final XMLPortalSigner portalSigner = new XMLPortalSigner()
                 .withPersonalIdentificationNumber("12345678910")
                 .withNotificationsUsingLookup(new XMLNotificationsUsingLookup().withEmail(new XMLEnabled()));
-        final XMLAvailability availability = new XMLAvailability().withActivationTime(ZonedDateTime.now(ZoneId.of("GMT")));
+        final XMLAvailability availability = new XMLAvailability().withActivationTime(ZonedDateTime.now(ZoneId.of("GMT")).truncatedTo(MILLIS));
 
 
         @Test

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-help-plugin</artifactId>
@@ -45,7 +45,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -145,7 +145,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.8.1</version>
                 </plugin>
 			</plugins>
 		</pluginManagement>

--- a/schema/examples/portal/legacy/manifest-legacy.xml
+++ b/schema/examples/portal/legacy/manifest-legacy.xml
@@ -31,20 +31,11 @@
     <sender>
         <organization-number>123456789</organization-number>
     </sender>
-    <title>Required job title</title>
-    <nonsensitive-title>Optional non-sensitive job title</nonsensitive-title>
-    <description>
-        Optional description of the job. May be a summary of the document to be signed,
-        or any message one wish to communicate when the signer is going to sign the document.
-    </description>
-    <documents>
-        <document href="document.pdf" mime="application/pdf">
-            <title>First document</title>
-        </document>
-        <document href="document2.pdf" mime="application/pdf">
-            <title>Second document</title>
-        </document>
-    </documents>
+    <document href="document.pdf" mime="application/pdf">
+        <title>Tittel</title>
+        <nonsensitive-title>Ikke-sensitiv tittel</nonsensitive-title>
+        <description>Melding til undertegner</description>
+    </document>
     <availability>
         <activation-time>2016-02-10T12:00:00+01:00</activation-time>
         <available-seconds>864000</available-seconds>

--- a/schema/xsd/direct.xsd
+++ b/schema/xsd/direct.xsd
@@ -150,6 +150,21 @@ for the default queue.
             <xs:sequence>
                 <xs:element name="signer" minOccurs="1" maxOccurs="10" type="direct-signer" />
                 <xs:element name="sender" minOccurs="1" maxOccurs="1" type="sender"/>
+                <xs:element name="title" minOccurs="0" maxOccurs="1">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:minLength value="1"/>
+                            <xs:maxLength value="80"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="description" minOccurs="0" maxOccurs="1">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:maxLength value="220"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
                 <xs:element name="document" minOccurs="1" maxOccurs="unbounded" type="direct-document"/>
                 <xs:element name="required-authentication" type="authentication-level" minOccurs="0" maxOccurs="1" />
                 <xs:element name="identifier-in-signed-documents" minOccurs="0" type="identifier-in-signed-documents"/>

--- a/schema/xsd/direct.xsd
+++ b/schema/xsd/direct.xsd
@@ -150,22 +150,7 @@ for the default queue.
             <xs:sequence>
                 <xs:element name="signer" minOccurs="1" maxOccurs="10" type="direct-signer" />
                 <xs:element name="sender" minOccurs="1" maxOccurs="1" type="sender"/>
-                <xs:element name="title" minOccurs="0" maxOccurs="1">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:minLength value="1"/>
-                            <xs:maxLength value="80"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="description" minOccurs="0" maxOccurs="1">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:maxLength value="220"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="document" minOccurs="1" maxOccurs="unbounded" type="direct-document"/>
+                <xs:element name="document" minOccurs="1" maxOccurs="1" type="direct-document"/>
                 <xs:element name="required-authentication" type="authentication-level" minOccurs="0" maxOccurs="1" />
                 <xs:element name="identifier-in-signed-documents" minOccurs="0" type="identifier-in-signed-documents"/>
             </xs:sequence>

--- a/schema/xsd/portal-legacy.xsd
+++ b/schema/xsd/portal-legacy.xsd
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) Posten Norge AS
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema version="1.0" targetNamespace="http://signering.posten.no/schema/v1" elementFormDefault="qualified"
+           xmlns="http://signering.posten.no/schema/v1"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.w3.org/2001/XMLSchema http://www.w3.org/2001/XMLSchema.xsd">
+
+    <xs:complexType name="legacy-portal-document">
+        <xs:sequence>
+            <xs:element name="title" minOccurs="1" maxOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="1"/>
+                        <xs:maxLength value="80"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="nonsensitive-title" minOccurs="0" maxOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="1"/>
+                        <xs:maxLength value="80"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="description" minOccurs="0" maxOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:maxLength value="220"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="href" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="4"/>
+                    <xs:maxLength value="100"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="mime" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="1"/>
+                    <xs:maxLength value="100"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+
+</xs:schema>

--- a/schema/xsd/portal.xsd
+++ b/schema/xsd/portal.xsd
@@ -171,6 +171,29 @@ for the default queue.
             <xs:sequence>
                 <xs:element name="signers" minOccurs="1" maxOccurs="1" type="portal-signers"/>
                 <xs:element name="sender" minOccurs="1" maxOccurs="1" type="sender"/>
+                <xs:element name="title" minOccurs="0" maxOccurs="1">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:minLength value="1"/>
+                            <xs:maxLength value="80"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="nonsensitive-title" minOccurs="0" maxOccurs="1">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:minLength value="1"/>
+                            <xs:maxLength value="80"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="description" minOccurs="0" maxOccurs="1">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:maxLength value="220"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
                 <xs:element name="document" minOccurs="1" maxOccurs="unbounded" type="portal-document"/>
                 <xs:element name="required-authentication" type="authentication-level" minOccurs="0" maxOccurs="1" />
                 <xs:element name="availability" minOccurs="0" maxOccurs="1" type="availability"/>

--- a/schema/xsd/portal.xsd
+++ b/schema/xsd/portal.xsd
@@ -23,6 +23,7 @@
            xsi:schemaLocation="http://www.w3.org/2001/XMLSchema http://www.w3.org/2001/XMLSchema.xsd">
 
     <xs:include schemaLocation="common.xsd"/>
+    <xs:include schemaLocation="portal-legacy.xsd"/>
 
     <xs:complexType name="portal-signers">
         <xs:sequence>
@@ -103,21 +104,6 @@ so three paralell signers with 1 day deadline will maximum take 1 day.
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="nonsensitive-title" minOccurs="0" maxOccurs="1">
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:minLength value="1"/>
-                        <xs:maxLength value="80"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="description" minOccurs="0" maxOccurs="1">
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:maxLength value="220"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
         </xs:sequence>
         <xs:attribute name="href" use="required">
             <xs:simpleType>
@@ -171,30 +157,41 @@ for the default queue.
             <xs:sequence>
                 <xs:element name="signers" minOccurs="1" maxOccurs="1" type="portal-signers"/>
                 <xs:element name="sender" minOccurs="1" maxOccurs="1" type="sender"/>
-                <xs:element name="title" minOccurs="0" maxOccurs="1">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:minLength value="1"/>
-                            <xs:maxLength value="80"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="nonsensitive-title" minOccurs="0" maxOccurs="1">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:minLength value="1"/>
-                            <xs:maxLength value="80"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="description" minOccurs="0" maxOccurs="1">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:maxLength value="220"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="document" minOccurs="1" maxOccurs="unbounded" type="portal-document"/>
+                <xs:choice>
+                    <xs:sequence>
+                        <xs:element name="title" minOccurs="1" maxOccurs="1">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:minLength value="1"/>
+                                    <xs:maxLength value="80"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="nonsensitive-title" minOccurs="0" maxOccurs="1">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:minLength value="1"/>
+                                    <xs:maxLength value="80"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="description" minOccurs="0" maxOccurs="1">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:maxLength value="220"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="documents" minOccurs="1" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="document" minOccurs="1" maxOccurs="unbounded" type="portal-document"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:element name="document" minOccurs="1" maxOccurs="1" type="legacy-portal-document"/>
+                </xs:choice>
                 <xs:element name="required-authentication" type="authentication-level" minOccurs="0" maxOccurs="1" />
                 <xs:element name="availability" minOccurs="0" maxOccurs="1" type="availability"/>
                 <xs:element name="identifier-in-signed-documents" minOccurs="0" type="identifier-in-signed-documents"/>


### PR DESCRIPTION
Forslag til design for å få inn oppdragstittel og beskrivelse på jobben, og ikke per dokument. Det er et par problemer med denne løsningen.

- Oppdragstittel kan ikke gjøres obligatorisk
- Kan ikke fjerne ikke-sensitiv tittel og beskrivelse fra dokumentene, selv om vi ikke bruker de lenger
- Tittel blir liggende på dokumentene, men får ny mening, som kan være litt forvirrende

Tanken er å skjule dette i klientene, så det blir tydelig hva som er meningen å bruke der. Og vi må legge på validering i backenden som styres av om det er et eller flere dokumenter (flere dokumenter krever oppdragstittel og gir ikke mulighet til å ha ikke-sensitiv tittel og beskrivelse på dokumentene)

Et annet alternativ er å begynne å versjonere xsd-filene våre. Da vil vi kunne bruke det i stede for custom validering i backenden, men må oversette de to variantene til den samme klassen før vi sender det videre fra API-laget. Dette vil nok gjøre det tydeligere hvordan API'et fungerer for de som ikke bruker klientene våre, men for de som bruker klienten bør vi kunne gi en like god opplevelse med begge løsningene.