### PR TITLE
Upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,14 +22,7 @@ updates:
   - dependency-name: org.jvnet.jaxb2_commons:jaxb2-basics-runtime
     versions:
     - "< 1.11.2, >= 1.11.1-PUBLISHED-BY-MISTAKE.a"
-  - dependency-name: org.springframework:spring-oxm
-    versions:
-    - 5.3.2
-    - 5.3.3
-  - dependency-name: nl.jqno.equalsverifier:equalsverifier
-    versions:
-    - "3.5"
-    - 3.5.2
-  - dependency-name: org.junit:junit-bom
-    versions:
-    - 5.7.0
+  - dependency-name: jakarta.xml.bind:jakarta.xml.bind-api
+    update-types: ["version-update:semver-major"]
+  - dependency-name: org.glassfish.jaxb:jaxb-runtime
+    update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "04:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: com.github.jaxb-xew-plugin:jaxb-xew-plugin
+    versions:
+    - "< 1.12, >= 1.11.a"
+  - dependency-name: org.jvnet.jaxb2_commons:jaxb2-basics
+    versions:
+    - "< 1.11.2, >= 1.11.1.a"
+  - dependency-name: org.jvnet.jaxb2_commons:jaxb2-basics
+    versions:
+    - "< 1.11.2, >= 1.11.1-PUBLISHED-BY-MISTAKE.a"
+  - dependency-name: org.jvnet.jaxb2_commons:jaxb2-basics-runtime
+    versions:
+    - "< 1.11.2, >= 1.11.1.a"
+  - dependency-name: org.jvnet.jaxb2_commons:jaxb2-basics-runtime
+    versions:
+    - "< 1.11.2, >= 1.11.1-PUBLISHED-BY-MISTAKE.a"
+  - dependency-name: org.springframework:spring-oxm
+    versions:
+    - 5.3.2
+    - 5.3.3
+  - dependency-name: nl.jqno.equalsverifier:equalsverifier
+    versions:
+    - "3.5"
+    - 3.5.2
+  - dependency-name: org.junit:junit-bom
+    versions:
+    - 5.7.0

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.4</version>
+            <version>2.3.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -224,6 +224,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.glassfish.jaxb</groupId>
+                        <artifactId>jaxb-runtime</artifactId>
+                        <version>2.3.5</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <specVersion>2.2</specVersion>
                     <schemaDirectory>${xsd.directory}</schemaDirectory>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -22,14 +22,14 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.8.0-M1</version>
+                <version>5.8.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>5.3.8</version>
+                <version>5.3.13</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.6.1</version>
+            <version>3.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -119,13 +119,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.31</version>
+            <version>1.7.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.31</version>
+            <version>1.7.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.0.0</version>
                     <configuration>
                         <rules>
                             <requireMavenVersion>


### PR DESCRIPTION
- Upgrading a few dependencies.
- Configure dependabot to ignore newer major versions of JAXB, because it would require some migration and not just a version bump.