### PR TITLE
Finalize v3

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -10,8 +10,8 @@ This software includes third party software subject to the following licenses:
 
   Digipost JAXB Resolver - com.sun.xml.bind under The Apache Software License, Version 2.0
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
+  JAXB Tools :: JAXB Basics :: Runtime under BSD-Style License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
-  JAXB2 Basics - Runtime under BSD-Style License
   Old JAXB Core under CDDL+GPL License
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
   Posten signering - API JAXB Classes under The Apache Software License, Version 2.0

--- a/jaxb/NOTICE
+++ b/jaxb/NOTICE
@@ -10,8 +10,8 @@ This software includes third party software subject to the following licenses:
 
   Digipost JAXB Resolver - com.sun.xml.bind under The Apache Software License, Version 2.0
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
+  JAXB Tools :: JAXB Basics :: Runtime under BSD-Style License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
-  JAXB2 Basics - Runtime under BSD-Style License
   Old JAXB Core under CDDL+GPL License
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
   Posten signering - API JAXB Classes under The Apache Software License, Version 2.0

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -64,9 +64,9 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <groupId>org.jvnet.jaxb</groupId>
             <artifactId>jaxb2-basics-runtime</artifactId>
-            <version>0.13.1</version>
+            <version>2.0.9</version>
         </dependency>
         <dependency>
             <groupId>no.digipost.signature</groupId>
@@ -145,11 +145,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.jvnet.jaxb2.maven2</groupId>
-                    <artifactId>maven-jaxb2-plugin</artifactId>
-                    <version>0.15.3</version>
+                    <groupId>org.jvnet.jaxb</groupId>
+                    <artifactId>jaxb-maven-plugin</artifactId>
+                    <version>2.0.9</version>
                     <configuration>
-                        <specVersion>2.2</specVersion>
+                        <specVersion>2.3</specVersion>
                         <schemaDirectory>${xsd.directory}</schemaDirectory>
                         <catalog>${xsd.directory}/catalog.xml</catalog>
                         <strict>false</strict>
@@ -169,24 +169,14 @@
                         </args>
                         <plugins>
                             <plugin>
-                                <groupId>org.jvnet.jaxb2_commons</groupId>
+                                <groupId>org.jvnet.jaxb</groupId>
                                 <artifactId>jaxb2-basics</artifactId>
-                                <version>0.13.1</version>
+                                <version>2.0.9</version>
                             </plugin>
                             <plugin>
-                                <groupId>org.jvnet.jaxb2_commons</groupId>
-                                <artifactId>jaxb2-basics-annotate</artifactId>
-                                <version>1.1.0</version>
-                            </plugin>
-                            <plugin>
-                                <groupId>org.jvnet.jaxb2_commons</groupId>
-                                <artifactId>jaxb2-fluent-api</artifactId>
-                                <version>3.0</version>
-                            </plugin>
-                            <plugin>
-                                <groupId>org.jvnet.jaxb2_commons</groupId>
-                                <artifactId>jaxb2-value-constructor</artifactId>
-                                <version>3.0</version>
+                                <groupId>org.jvnet.jaxb</groupId>
+                                <artifactId>jaxb-basics-annotate</artifactId>
+                                <version>2.0.9</version>
                             </plugin>
                             <plugin>
                                 <groupId>org.apache.cxf.xjcplugins</groupId>
@@ -229,8 +219,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
+                <groupId>org.jvnet.jaxb</groupId>
+                <artifactId>jaxb-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>xmldsig</id>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.9.2</version>
+                <version>5.10.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -106,13 +106,13 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.14</version>
+            <version>3.15.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.javers</groupId>
             <artifactId>javers-core</artifactId>
-            <version>6.9.1</version>
+            <version>6.14.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -124,13 +124,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.6</version>
+            <version>2.0.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.6</version>
+            <version>2.0.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -30,7 +30,8 @@
     <artifactId>signature-api-specification-jaxb</artifactId>
 
     <properties>
-        <xsd.directory>${project.basedir}/target/generated-resources/xsd</xsd.directory>
+        <xsd.directory>${project.build.directory}/generated-resources/xsd</xsd.directory>
+        <xjc.build.directory>${project.build.directory}/generated-sources/xjc</xjc.build.directory>
     </properties>
 
     <dependencyManagement>
@@ -65,7 +66,7 @@
         <dependency>
             <groupId>org.jvnet.jaxb2_commons</groupId>
             <artifactId>jaxb2-basics-runtime</artifactId>
-            <version>0.12.0</version>
+            <version>0.13.1</version>
         </dependency>
         <dependency>
             <groupId>no.digipost.signature</groupId>
@@ -146,7 +147,59 @@
                 <plugin>
                     <groupId>org.jvnet.jaxb2.maven2</groupId>
                     <artifactId>maven-jaxb2-plugin</artifactId>
-                    <version>0.14.0</version>
+                    <version>0.15.3</version>
+                    <configuration>
+                        <specVersion>2.2</specVersion>
+                        <schemaDirectory>${xsd.directory}</schemaDirectory>
+                        <catalog>${xsd.directory}/catalog.xml</catalog>
+                        <strict>false</strict>
+                        <extension>true</extension>
+                        <bindingDirectory>${project.basedir}/src/main/jaxb</bindingDirectory>
+                        <args>
+                            <arg>-Xxew</arg>
+                            <arg>-Xxew:instantiate lazy</arg>
+                            <arg>-Xxew:control ${project.basedir}/src/main/jaxb/xew-control.properties</arg>
+                            <arg>-XtoString</arg>
+                            <arg>-XtoString-toStringStrategyClass=no.digipost.signature.jaxb.basics.LessFuzzToStringStrategy</arg>
+                            <arg>-Xjavadoc</arg>
+                            <arg>-Xvalue-constructor</arg>
+                            <arg>-Xfluent-api</arg>
+                            <arg>-Xinheritance</arg>
+                            <arg>-Xannotate</arg>
+                        </args>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.jvnet.jaxb2_commons</groupId>
+                                <artifactId>jaxb2-basics</artifactId>
+                                <version>0.13.1</version>
+                            </plugin>
+                            <plugin>
+                                <groupId>org.jvnet.jaxb2_commons</groupId>
+                                <artifactId>jaxb2-basics-annotate</artifactId>
+                                <version>1.1.0</version>
+                            </plugin>
+                            <plugin>
+                                <groupId>org.jvnet.jaxb2_commons</groupId>
+                                <artifactId>jaxb2-fluent-api</artifactId>
+                                <version>3.0</version>
+                            </plugin>
+                            <plugin>
+                                <groupId>org.jvnet.jaxb2_commons</groupId>
+                                <artifactId>jaxb2-value-constructor</artifactId>
+                                <version>3.0</version>
+                            </plugin>
+                            <plugin>
+                                <groupId>org.apache.cxf.xjcplugins</groupId>
+                                <artifactId>cxf-xjc-javadoc</artifactId>
+                                <version>3.3.2</version>
+                            </plugin>
+                            <plugin>
+                                <groupId>com.github.jaxb-xew-plugin</groupId>
+                                <artifactId>jaxb-xew-plugin</artifactId>
+                                <version>1.11</version>
+                            </plugin>
+                        </plugins>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
@@ -180,75 +233,96 @@
                 <artifactId>maven-jaxb2-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>xmldsig</id>
                         <goals>
                             <goal>generate</goal>
                         </goals>
+                        <configuration>
+                            <bindingIncludes>bindings-xmldsig.xjb</bindingIncludes>
+                            <generateDirectory>${xjc.build.directory}/xmldsig</generateDirectory>
+                            <schemaIncludes>
+                                <include>thirdparty/xmldsig-core-schema.xsd</include>
+                            </schemaIncludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>xades</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <bindingIncludes>bindings-xades.xjb</bindingIncludes>
+                            <generateDirectory>${xjc.build.directory}/xades</generateDirectory>
+                            <schemaIncludes>
+                                <include>thirdparty/XAdES.xsd</include>
+                            </schemaIncludes>
+                            <args combine.children="append">
+                                <arg>-b</arg>
+                                <arg>${xjc.build.directory}/xmldsig/META-INF/sun-jaxb.episode</arg>
+                            </args>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>asice</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <bindingIncludes>bindings-ts_102918v010201.xjb</bindingIncludes>
+                            <generateDirectory>${xjc.build.directory}/asice</generateDirectory>
+                            <schemaIncludes>
+                                <include>thirdparty/ts_102918v010201.xsd</include>
+                            </schemaIncludes>
+                            <args combine.children="append">
+                                <arg>-b</arg>
+                                <arg>${xjc.build.directory}/xmldsig/META-INF/sun-jaxb.episode</arg>
+                            </args>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>sign</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <bindingIncludes>bindings-sign.xjb</bindingIncludes>
+                            <generateDirectory>${xjc.build.directory}/sign</generateDirectory>
+                            <schemaIncludes>
+                                <include>direct-and-portal.xsd</include>
+                            </schemaIncludes>
+                            <args combine.children="append">
+                                <arg>-b</arg>
+                                <arg>${xjc.build.directory}/asice/META-INF/sun-jaxb.episode</arg>
+                                <arg>-b</arg>
+                                <arg>${xjc.build.directory}/xades/META-INF/sun-jaxb.episode</arg>
+                            </args>
+                        </configuration>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.glassfish.jaxb</groupId>
-                        <artifactId>jaxb-runtime</artifactId>
-                        <version>2.3.8</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <specVersion>2.2</specVersion>
-                    <schemaDirectory>${xsd.directory}</schemaDirectory>
-                    <schemaIncludes>
-                        <include>direct-and-portal.xsd</include>
-                        <include>thirdparty/*.xsd</include>
-                    </schemaIncludes>
-                    <catalog>${xsd.directory}/catalog.xml</catalog>
-                    <strict>false</strict>
-                    <extension>true</extension>
-                    <removeOldOutput>true</removeOldOutput>
-                    <bindingDirectory>${project.basedir}/src/main/jaxb</bindingDirectory>
-                    <args>
-                        <arg>-Xxew</arg>
-                        <arg>-Xxew:instantiate lazy</arg>
-                        <arg>-Xxew:control ${project.basedir}/src/main/jaxb/xew-control.properties</arg>
-                        <arg>-XtoString</arg>
-                        <arg>-XtoString-toStringStrategyClass=no.digipost.signature.jaxb.basics.LessFuzzToStringStrategy</arg>
-                        <arg>-Xjavadoc</arg>
-                        <arg>-Xvalue-constructor</arg>
-                        <arg>-Xfluent-api</arg>
-                        <arg>-Xinheritance</arg>
-                        <arg>-Xannotate</arg>
-                    </args>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.jvnet.jaxb2_commons</groupId>
-                            <artifactId>jaxb2-basics</artifactId>
-                            <version>0.12.0</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.jvnet.jaxb2_commons</groupId>
-                            <artifactId>jaxb2-basics-annotate</artifactId>
-                            <version>1.1.0</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.jvnet.jaxb2_commons</groupId>
-                            <artifactId>jaxb2-fluent-api</artifactId>
-                            <version>3.0</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.jvnet.jaxb2_commons</groupId>
-                            <artifactId>jaxb2-value-constructor</artifactId>
-                            <version>3.0</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.cxf.xjcplugins</groupId>
-                            <artifactId>cxf-xjc-javadoc</artifactId>
-                            <version>3.3.1</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>com.github.jaxb-xew-plugin</groupId>
-                            <artifactId>jaxb-xew-plugin</artifactId>
-                            <version>1.10</version>
-                        </plugin>
-                    </plugins>
-                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- This is a hack to remove excess ObjectFactory classes generated by xjc,
+                                     even though the use of episodes are supposed to prevent that from happening.
+                                     Seems like DigestValue, mapped to a Java byte[], is not included in the
+                                     episode file generated from the compilation of xmldsig-core-schema, and are therefore
+                                     regenerated in the compilation of xades.xsd and ts_102918v010201.xsd, resulting in a
+                                     duplicate class error when compiling the generated Java code.
+                                     See https://stackoverflow.com/a/32649545 -->
+                                <delete dir="${xjc.build.directory}/asice/no/digipost/signature/api/xml/thirdparty/xmldsig"/>
+                                <delete dir="${xjc.build.directory}/xades/no/digipost/signature/api/xml/thirdparty/xmldsig"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>

--- a/jaxb/src/main/jaxb/bindings-sign.xjb
+++ b/jaxb/src/main/jaxb/bindings-sign.xjb
@@ -134,20 +134,4 @@
         </bindings>
     </bindings>
 
-    <bindings schemaLocation="../../../target/generated-resources/xsd/thirdparty/ts_102918v010201.xsd" node="/xs:schema">
-        <schemaBindings>
-            <package name="no.digipost.signature.api.xml.thirdparty.asice" />
-        </schemaBindings>
-    </bindings>
-    <bindings schemaLocation="../../../target/generated-resources/xsd/thirdparty/XAdES.xsd" node="/xs:schema">
-        <schemaBindings>
-            <package name="no.digipost.signature.api.xml.thirdparty.xades" />
-        </schemaBindings>
-    </bindings>
-    <bindings schemaLocation="../../../target/generated-resources/xsd/thirdparty/xmldsig-core-schema.xsd" node="/xs:schema">
-        <schemaBindings>
-            <package name="no.digipost.signature.api.xml.thirdparty.xmldsig" />
-        </schemaBindings>
-    </bindings>
-
 </bindings>

--- a/jaxb/src/main/jaxb/bindings-ts_102918v010201.xjb
+++ b/jaxb/src/main/jaxb/bindings-ts_102918v010201.xjb
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) Posten Norge AS
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<bindings version="2.1"
+          xmlns="http://java.sun.com/xml/ns/jaxb"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+          xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb https://raw.githubusercontent.com/eclipse-ee4j/jaxb-api/2.3.2/bindingschema.xsd"
+          extensionBindingPrefixes="xjc">
+
+    <globalBindings>
+        <xjc:simple/>
+    </globalBindings>
+
+    <bindings schemaLocation="../../../target/generated-resources/xsd/thirdparty/ts_102918v010201.xsd" node="/xs:schema">
+        <schemaBindings>
+            <package name="no.digipost.signature.api.xml.thirdparty.asice" />
+        </schemaBindings>
+    </bindings>
+
+</bindings>

--- a/jaxb/src/main/jaxb/bindings-xades.xjb
+++ b/jaxb/src/main/jaxb/bindings-xades.xjb
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) Posten Norge AS
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<bindings version="2.1"
+          xmlns="http://java.sun.com/xml/ns/jaxb"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+          xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb https://raw.githubusercontent.com/eclipse-ee4j/jaxb-api/2.3.2/bindingschema.xsd"
+          extensionBindingPrefixes="xjc">
+
+    <globalBindings>
+        <xjc:simple/>
+        <xjc:javaType adapter="no.digipost.signature.jaxb.adapter.DateTimeXmlAdapter" name="java.time.ZonedDateTime" xmlType="xs:dateTime"/>
+    </globalBindings>
+
+    <bindings schemaLocation="../../../target/generated-resources/xsd/thirdparty/XAdES.xsd" node="/xs:schema">
+        <schemaBindings>
+            <package name="no.digipost.signature.api.xml.thirdparty.xades" />
+        </schemaBindings>
+    </bindings>
+
+</bindings>

--- a/jaxb/src/main/jaxb/bindings-xmldsig.xjb
+++ b/jaxb/src/main/jaxb/bindings-xmldsig.xjb
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) Posten Norge AS
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<bindings version="2.1"
+          xmlns="http://java.sun.com/xml/ns/jaxb"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+          xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb https://raw.githubusercontent.com/eclipse-ee4j/jaxb-api/2.3.2/bindingschema.xsd"
+          extensionBindingPrefixes="xjc">
+
+    <globalBindings>
+        <xjc:simple/>
+    </globalBindings>
+
+    <bindings schemaLocation="../../../target/generated-resources/xsd/thirdparty/xmldsig-core-schema.xsd" node="/xs:schema">
+        <schemaBindings>
+            <package name="no.digipost.signature.api.xml.thirdparty.xmldsig" />
+        </schemaBindings>
+    </bindings>
+
+</bindings>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,10 @@
                     <version>3.1.1</version>
                 </plugin>
                 <plugin>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>2.16.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,19 +50,19 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-help-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -70,7 +70,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.4.1</version>
                     <configuration>
                         <rules>
                             <bannedDependencies>
@@ -90,7 +90,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M9</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
@@ -98,21 +98,21 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.15.0</version>
+                    <version>2.16.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>4.2.rc3</version>
+                    <version>4.2</version>
                     <configuration>
                         <licenseSets>
                             <licenseSet>
@@ -128,7 +128,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.17.2</version>
+                    <version>0.17.3</version>
                     <configuration>
                         <parameter>
                             <includes>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -48,7 +48,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>xml-maven-plugin</artifactId>
-                    <version>1.0.2</version>
+                    <version>1.1.0</version>
                     <configuration>
                         <catalogs>
                             <catalog>src/validation/catalog.xml</catalog>


### PR DESCRIPTION
Finishing touches before a 3.0.0 final release.

Basically getting dependencies and JAXB stuff up to speed with the recent restructuring of the https://github.com/highsource/jaxb-tools.

Also see commit message of c8ba048b2df4dad5ce12bbe58014eabd572bac52 for some wall-of-text explaining the rationale for modularizing the JAXB/XJC compilation.